### PR TITLE
Fix markdown list rendering bug

### DIFF
--- a/src/web-ui/components/MarkdownRenderer.tsx
+++ b/src/web-ui/components/MarkdownRenderer.tsx
@@ -48,17 +48,17 @@ export default function MarkdownRenderer({ children, className = 'prose prose-gr
             </a>
           ),
           ul: ({ children, ...props }) => (
-            <ul className="list-disc list-inside space-y-1 my-4" {...props}>
+            <ul className="list-disc list-outside ml-6 space-y-1 my-4" {...props}>
               {children}
             </ul>
           ),
           ol: ({ children, ...props }) => (
-            <ol className="list-decimal list-inside space-y-1 my-4" {...props}>
+            <ol className="list-decimal list-outside ml-6 space-y-1 my-4" {...props}>
               {children}
             </ol>
           ),
           li: ({ children, ...props }) => (
-            <li className="mb-1" {...props}>
+            <li className="mb-1 pl-1" {...props}>
               {children}
             </li>
           ),

--- a/src/web-ui/test/components/MarkdownRenderer.test.tsx
+++ b/src/web-ui/test/components/MarkdownRenderer.test.tsx
@@ -6,11 +6,83 @@ import MarkdownRenderer from '../../components/MarkdownRenderer';
 // Mock ReactMarkdown and its plugins
 vi.mock('react-markdown', () => ({
   default: ({ children, components }: any) => {
-    // Simulate the behavior of ReactMarkdown with inline code
     const content = children || '';
     
-    // Find inline code patterns like `code here`
+    // Handle lists - look for numbered and bulleted lists
+    const listRegex = /^(\d+\.|\•)\s*(.+)$/gm;
     const inlineCodeRegex = /`([^`]+)`/g;
+    
+    // Check if content contains lists
+    if (listRegex.test(content)) {
+      const lines = content.split('\n');
+      const elements: any[] = [];
+      let currentList: any[] = [];
+      let listType: 'ol' | 'ul' | null = null;
+      
+      lines.forEach((line: string, index: number) => {
+        const trimmedLine = line.trim();
+        const numberedMatch = trimmedLine.match(/^(\d+)\.\s*(.+)$/);
+        const bulletMatch = trimmedLine.match(/^•\s*(.+)$/);
+        
+        if (numberedMatch) {
+          if (listType !== 'ol') {
+            if (currentList.length > 0 && components) {
+              const ListComponent = listType === 'ul' ? components.ul : components.ol;
+              elements.push(
+                <ListComponent key={elements.length}>
+                  {currentList.map((item, i) => {
+                    const LiComponent = components.li;
+                    return LiComponent ? <LiComponent key={i}>{item}</LiComponent> : <li key={i}>{item}</li>;
+                  })}
+                </ListComponent>
+              );
+            }
+            currentList = [];
+            listType = 'ol';
+          }
+          currentList.push(numberedMatch[2]);
+        } else if (bulletMatch) {
+          if (listType !== 'ul') {
+            if (currentList.length > 0 && components) {
+              const ListComponent = listType === 'ol' ? components.ol : components.ul;
+              elements.push(
+                <ListComponent key={elements.length}>
+                  {currentList.map((item, i) => {
+                    const LiComponent = components.li;
+                    return LiComponent ? <LiComponent key={i}>{item}</LiComponent> : <li key={i}>{item}</li>;
+                  })}
+                </ListComponent>
+              );
+            }
+            currentList = [];
+            listType = 'ul';
+          }
+          currentList.push(bulletMatch[1]);
+        } else if (trimmedLine && currentList.length > 0) {
+          // Handle list item content that continues on the next line
+          if (currentList.length > 0) {
+            currentList[currentList.length - 1] += ` ${trimmedLine}`;
+          }
+        }
+      });
+      
+      // Add the final list if there is one
+      if (currentList.length > 0 && components && listType) {
+        const ListComponent = components[listType];
+        elements.push(
+          <ListComponent key={elements.length}>
+            {currentList.map((item, i) => {
+              const LiComponent = components.li;
+              return LiComponent ? <LiComponent key={i}>{item}</LiComponent> : <li key={i}>{item}</li>;
+            })}
+          </ListComponent>
+        );
+      }
+      
+      return <div data-testid="markdown-content">{elements}</div>;
+    }
+    
+    // Handle inline code as before
     const parts = content.split(inlineCodeRegex);
     
     return (
@@ -216,6 +288,157 @@ describe('MarkdownRenderer', () => {
       expect(container).toHaveClass('prose-gray');
       expect(container).toHaveClass('dark:prose-invert');
       expect(container).toHaveClass('max-w-none');
+    });
+  });
+
+  describe('List Rendering', () => {
+    describe('Ordered Lists', () => {
+      it('should render numbered lists with correct CSS classes', () => {
+        render(
+          <MarkdownRenderer>
+            {`1. First item
+2. Second item
+3. Third item`}
+          </MarkdownRenderer>
+        );
+
+        const orderedList = screen.getByRole('list');
+        expect(orderedList).toBeInTheDocument();
+        expect(orderedList.tagName).toBe('OL');
+        expect(orderedList).toHaveClass('list-decimal');
+        expect(orderedList).toHaveClass('list-outside');
+        expect(orderedList).toHaveClass('ml-6');
+        expect(orderedList).toHaveClass('space-y-1');
+        expect(orderedList).toHaveClass('my-4');
+      });
+
+      it('should render numbered list items with proper content', () => {
+        render(
+          <MarkdownRenderer>
+            {`1. Context Intake
+2. Automated Pass (quick)
+3. Deep Analysis`}
+          </MarkdownRenderer>
+        );
+
+        expect(screen.getByText('Context Intake')).toBeInTheDocument();
+        expect(screen.getByText('Automated Pass (quick)')).toBeInTheDocument();
+        expect(screen.getByText('Deep Analysis')).toBeInTheDocument();
+      });
+
+      it('should handle multi-line list items correctly', () => {
+        render(
+          <MarkdownRenderer>
+            {`1. **Context Intake**
+   Review the change description and understand the goal
+2. **Automated Pass**
+   Look for obvious issues`}
+          </MarkdownRenderer>
+        );
+
+        expect(screen.getByText(/Context Intake.*Review the change description/)).toBeInTheDocument();
+        expect(screen.getByText(/Automated Pass.*Look for obvious issues/)).toBeInTheDocument();
+      });
+    });
+
+    describe('Unordered Lists', () => {
+      it('should render bulleted lists with correct CSS classes', () => {
+        render(
+          <MarkdownRenderer>
+            {`• First bullet
+• Second bullet
+• Third bullet`}
+          </MarkdownRenderer>
+        );
+
+        const unorderedList = screen.getByRole('list');
+        expect(unorderedList).toBeInTheDocument();
+        expect(unorderedList.tagName).toBe('UL');
+        expect(unorderedList).toHaveClass('list-disc');
+        expect(unorderedList).toHaveClass('list-outside');
+        expect(unorderedList).toHaveClass('ml-6');
+        expect(unorderedList).toHaveClass('space-y-1');
+        expect(unorderedList).toHaveClass('my-4');
+      });
+
+      it('should render bulleted list items with proper content', () => {
+        render(
+          <MarkdownRenderer>
+            {`• Review the change description and understand the goal
+• Identify the change scope (diff, commit list, or directory)
+• Read surrounding code to understand intent and style`}
+          </MarkdownRenderer>
+        );
+
+        expect(screen.getByText('Review the change description and understand the goal')).toBeInTheDocument();
+        expect(screen.getByText('Identify the change scope (diff, commit list, or directory)')).toBeInTheDocument();
+        expect(screen.getByText('Read surrounding code to understand intent and style')).toBeInTheDocument();
+      });
+
+      it('should handle multi-line bulleted list items', () => {
+        render(
+          <MarkdownRenderer>
+            {`• Line-by-line inspection
+  Check security, performance, error handling
+• Note violations of SOLID, DRY, KISS
+  Follow least-privilege principles`}
+          </MarkdownRenderer>
+        );
+
+        expect(screen.getByText(/Line-by-line inspection.*Check security, performance/)).toBeInTheDocument();
+        expect(screen.getByText(/Note violations of SOLID.*Follow least-privilege/)).toBeInTheDocument();
+      });
+    });
+
+    describe('List Items', () => {
+      it('should render list items with correct CSS classes', () => {
+        render(
+          <MarkdownRenderer>
+            {`1. First item
+2. Second item`}
+          </MarkdownRenderer>
+        );
+
+        const listItems = screen.getAllByRole('listitem');
+        listItems.forEach(item => {
+          expect(item).toHaveClass('mb-1');
+          expect(item).toHaveClass('pl-1');
+        });
+      });
+
+      it('should handle complex list item content', () => {
+        render(
+          <MarkdownRenderer>
+            {`1. **Context Intake**
+   
+   • Review the change description and understand the goal of the change
+   • Identify the change scope (diff, commit list, or directory)
+   • Read surrounding code to understand intent and style
+   • Gather test status and coverage reports if present`}
+          </MarkdownRenderer>
+        );
+
+        // The mock treats ** as literal text, so we check for the exact text
+        expect(screen.getByText('**Context Intake**')).toBeInTheDocument();
+        expect(screen.getByText('Review the change description and understand the goal of the change')).toBeInTheDocument();
+        expect(screen.getByText('Gather test status and coverage reports if present')).toBeInTheDocument();
+      });
+    });
+
+    describe('Severity Lists', () => {
+      it('should handle severity delegation list format', () => {
+        render(
+          <MarkdownRenderer>
+            {`• 🔴 **Critical** – must fix now
+• 🟡 **Major** – should fix soon  
+• 🟢 **Minor** – style / docs`}
+          </MarkdownRenderer>
+        );
+
+        expect(screen.getByText('🔴 **Critical** – must fix now')).toBeInTheDocument();
+        expect(screen.getByText('🟡 **Major** – should fix soon')).toBeInTheDocument();
+        expect(screen.getByText('🟢 **Minor** – style / docs')).toBeInTheDocument();
+      });
     });
   });
 


### PR DESCRIPTION
# Description

Fixes a UI bug where Markdown lists in the memory bank web-ui were incorrectly formatted. The previous `list-inside` styling caused list content to appear on new lines or nested lists to collapse onto a single line.

This PR updates the `MarkdownRenderer.tsx` to use `list-outside` for `ul` and `ol` elements, adds `ml-6` for proper indentation, and `pl-1` to `li` elements for improved spacing. Comprehensive tests have been added to ensure correct rendering of various list types and complex content.

Fixes #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the documentation accordingly
- [ ] My changes maintain project isolation and security
- [ ] I have tested my changes with the MCP server running
- [ ] I have verified the memory bank file operations still work correctly

## Additional Notes

The primary changes are in `src/web-ui/components/MarkdownRenderer.tsx` to adjust Tailwind CSS classes for list elements and in `src/web-ui/test/components/MarkdownRenderer.test.tsx` to add detailed test cases for list rendering.

---
<a href="https://cursor.com/background-agent?bcId=bc-2f13fa57-5771-42db-bbf8-0a8168d80551">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2f13fa57-5771-42db-bbf8-0a8168d80551">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

