### PR TITLE
feat: add project name normalization with friendly name aliasing and metadata tracking

### DIFF
--- a/src/data/helpers/index.ts
+++ b/src/data/helpers/index.ts
@@ -1,1 +1,2 @@
 export { normalizeLineEndings, normalizeForComparison } from "./content-normalizer.js";
+export { normalizeProjectName } from "./normalize-project-name.js";

--- a/src/data/helpers/normalize-project-name.ts
+++ b/src/data/helpers/normalize-project-name.ts
@@ -97,13 +97,13 @@ export function normalizeProjectName(input: string): string {
   normalized = normalized.replace(/\.{2,}/g, ".");
 
   // Remove leading/trailing hyphens and dots
-  normalized = normalized.replace(/^[-.]/, "").replace(/[-.]$/, "");
+  normalized = normalized.replace(/^[-.]+|[-.]+$/g, "");
 
   // Truncate to max length
   if (normalized.length > MAX_NAME_LENGTH) {
     normalized = normalized.slice(0, MAX_NAME_LENGTH);
     // Clean up trailing hyphens/dots from truncation
-    normalized = normalized.replace(/[-.]$/, "");
+    normalized = normalized.replace(/[-.]+$/, "");
   }
 
   if (!normalized) {

--- a/src/data/helpers/normalize-project-name.ts
+++ b/src/data/helpers/normalize-project-name.ts
@@ -1,0 +1,116 @@
+/**
+ * Maximum allowed length for a normalized project directory name.
+ * Most filesystems support 255 bytes; we use a conservative limit.
+ */
+const MAX_NAME_LENGTH = 200;
+
+/**
+ * Common Unicode character transliterations to ASCII equivalents.
+ */
+const TRANSLITERATIONS: Record<string, string> = {
+  ä: "ae",
+  ö: "oe",
+  ü: "ue",
+  ß: "ss",
+  à: "a",
+  á: "a",
+  â: "a",
+  ã: "a",
+  å: "a",
+  æ: "ae",
+  ç: "c",
+  è: "e",
+  é: "e",
+  ê: "e",
+  ë: "e",
+  ì: "i",
+  í: "i",
+  î: "i",
+  ï: "i",
+  ñ: "n",
+  ò: "o",
+  ó: "o",
+  ô: "o",
+  õ: "o",
+  ø: "o",
+  ù: "u",
+  ú: "u",
+  û: "u",
+  ý: "y",
+  ÿ: "y",
+  đ: "d",
+  ð: "d",
+  þ: "th",
+  ł: "l",
+  ž: "z",
+  š: "s",
+  č: "c",
+  ř: "r",
+  ů: "u",
+  ě: "e",
+  ť: "t",
+  ď: "d",
+  ň: "n",
+};
+
+/**
+ * Normalizes a user-provided project name into a filesystem-safe directory name.
+ *
+ * Rules applied in order:
+ * 1. Trim whitespace
+ * 2. Convert to lowercase
+ * 3. Transliterate common Unicode characters to ASCII
+ * 4. Replace spaces and underscores with hyphens
+ * 5. Remove characters that are not a-z, 0-9, hyphens, or dots
+ * 6. Collapse consecutive hyphens into one
+ * 7. Remove leading/trailing hyphens and dots
+ * 8. Truncate to MAX_NAME_LENGTH
+ * 9. Reject empty results
+ *
+ * @param input The user-provided project name
+ * @returns The normalized, filesystem-safe directory name
+ * @throws Error if the input is empty or normalizes to an empty string
+ */
+export function normalizeProjectName(input: string): string {
+  if (!input || !input.trim()) {
+    throw new Error("Project name cannot be empty");
+  }
+
+  let normalized = input.trim().toLowerCase();
+
+  // Transliterate common Unicode characters
+  normalized = normalized
+    .split("")
+    .map((char) => TRANSLITERATIONS[char] ?? char)
+    .join("");
+
+  // Replace spaces and underscores with hyphens
+  normalized = normalized.replace(/[\s_]+/g, "-");
+
+  // Remove characters that are not a-z, 0-9, hyphens, or dots
+  normalized = normalized.replace(/[^a-z0-9.-]/g, "");
+
+  // Collapse consecutive hyphens
+  normalized = normalized.replace(/-{2,}/g, "-");
+
+  // Collapse consecutive dots
+  normalized = normalized.replace(/\.{2,}/g, ".");
+
+  // Remove leading/trailing hyphens and dots
+  normalized = normalized.replace(/^[-.]/, "").replace(/[-.]$/, "");
+
+  // Truncate to max length
+  if (normalized.length > MAX_NAME_LENGTH) {
+    normalized = normalized.slice(0, MAX_NAME_LENGTH);
+    // Clean up trailing hyphens/dots from truncation
+    normalized = normalized.replace(/[-.]$/, "");
+  }
+
+  if (!normalized) {
+    throw new Error(
+      `Project name "${input}" cannot be normalized to a valid directory name`
+    );
+  }
+
+  return normalized;
+}

--- a/src/data/helpers/normalize-project-name.ts
+++ b/src/data/helpers/normalize-project-name.ts
@@ -78,6 +78,11 @@ export function normalizeProjectName(input: string): string {
 
   let normalized = input.trim().toLowerCase();
 
+  // Normalize to NFC so decomposed Unicode (e.g. NFD from macOS) is precomposed
+  // before transliteration. Without this, decomposed forms like u+\u0308 won't
+  // match the TRANSLITERATIONS map entries for precomposed characters like ü.
+  normalized = normalized.normalize("NFC");
+
   // Transliterate common Unicode characters
   normalized = normalized
     .split("")

--- a/src/data/protocols/index.ts
+++ b/src/data/protocols/index.ts
@@ -3,3 +3,5 @@ export * from "./project-repository.js";
 export * from "./prompt-repository.js";
 export * from "./history-repository.js";
 export * from "./lock-service.js";
+export * from "./metadata-repository.js";
+export * from "./project-index-repository.js";

--- a/src/data/protocols/metadata-repository.ts
+++ b/src/data/protocols/metadata-repository.ts
@@ -1,0 +1,21 @@
+import { ProjectMetadata } from "../../domain/entities/index.js";
+
+/**
+ * Repository for reading and writing project metadata (.metadata.json files).
+ */
+export interface MetadataRepository {
+  /**
+   * Reads metadata for a project by its directory name.
+   * @returns The metadata, or null if no .metadata.json exists.
+   */
+  readMetadata(directoryName: string): Promise<ProjectMetadata | null>;
+
+  /**
+   * Writes metadata for a project by its directory name.
+   * Creates or overwrites the .metadata.json file.
+   */
+  writeMetadata(
+    directoryName: string,
+    metadata: ProjectMetadata
+  ): Promise<void>;
+}

--- a/src/data/protocols/project-index-repository.ts
+++ b/src/data/protocols/project-index-repository.ts
@@ -1,0 +1,34 @@
+/**
+ * Repository for managing the global project name index (.index file).
+ * Maps friendly project names to filesystem directory names.
+ */
+export interface ProjectIndexRepository {
+  /**
+   * Looks up a directory name by friendly name.
+   * @returns The directory name, or null if no mapping exists.
+   */
+  getDirectoryName(friendlyName: string): Promise<string | null>;
+
+  /**
+   * Stores a mapping from friendly name to directory name.
+   */
+  setMapping(friendlyName: string, directoryName: string): Promise<void>;
+
+  /**
+   * Removes a mapping by friendly name.
+   */
+  removeMapping(friendlyName: string): Promise<void>;
+
+  /**
+   * Returns all mappings as a Record<friendlyName, directoryName>.
+   */
+  getAllMappings(): Promise<Record<string, string>>;
+
+  /**
+   * Replaces the entire index with the provided entries.
+   * Used for index regeneration / recovery.
+   */
+  rebuildIndex(
+    entries: Array<{ friendlyName: string; directoryName: string }>
+  ): Promise<void>;
+}

--- a/src/data/services/project-name-resolver.ts
+++ b/src/data/services/project-name-resolver.ts
@@ -1,0 +1,111 @@
+import { ProjectIndexRepository } from "../protocols/project-index-repository.js";
+import { ProjectRepository } from "../protocols/project-repository.js";
+import { normalizeProjectName } from "../helpers/normalize-project-name.js";
+
+/**
+ * Result of resolving a project name for creation.
+ */
+export interface ResolveForCreationResult {
+  /** The filesystem-safe directory name */
+  directoryName: string;
+  /** The original friendly name provided by the user */
+  friendlyName: string;
+  /** Whether this is a new project (true) or an existing one (false) */
+  isNew: boolean;
+}
+
+/**
+ * Protocol interface for the ProjectNameResolver service.
+ */
+export interface ProjectNameResolverService {
+  /**
+   * Resolves a user-provided project name to an existing directory name.
+   * Checks: exact directory match -> index lookup -> normalized name match.
+   * @returns The directory name, or null if no matching project exists.
+   */
+  resolve(input: string): Promise<string | null>;
+
+  /**
+   * Resolves a project name for creation.
+   * If the project already exists, returns the existing directory name.
+   * If new, normalizes the name and handles collisions.
+   */
+  resolveForCreation(input: string): Promise<ResolveForCreationResult>;
+}
+
+/**
+ * Service that resolves user-provided project names (which may be friendly
+ * names with spaces/special chars) to filesystem-safe directory names.
+ */
+export class ProjectNameResolver implements ProjectNameResolverService {
+  constructor(
+    private readonly projectRepository: ProjectRepository,
+    private readonly indexRepository: ProjectIndexRepository
+  ) {}
+
+  async resolve(input: string): Promise<string | null> {
+    // 1. Check if input is an existing directory name directly
+    if (await this.directoryExists(input)) {
+      return input;
+    }
+
+    // 2. Check index for input as a friendly name
+    const mappedDir = await this.indexRepository.getDirectoryName(input);
+    if (mappedDir !== null && (await this.directoryExists(mappedDir))) {
+      return mappedDir;
+    }
+
+    // 3. Try normalizing input and check if that directory exists
+    try {
+      const normalized = normalizeProjectName(input);
+      if (normalized !== input && (await this.directoryExists(normalized))) {
+        return normalized;
+      }
+    } catch {
+      // Normalization failed (e.g., empty result) — project doesn't exist
+    }
+
+    return null;
+  }
+
+  async resolveForCreation(input: string): Promise<ResolveForCreationResult> {
+    // 1. Try to resolve to an existing project
+    const existing = await this.resolve(input);
+    if (existing !== null) {
+      return {
+        directoryName: existing,
+        friendlyName: input,
+        isNew: false,
+      };
+    }
+
+    // 2. Normalize for a new project
+    const candidate = normalizeProjectName(input);
+
+    // 3. Handle collisions: if candidate directory exists (unmapped legacy project),
+    //    append incrementing suffix
+    let finalName = candidate;
+    let suffix = 1;
+    while (await this.directoryExists(finalName)) {
+      finalName = `${candidate}-${suffix}`;
+      suffix++;
+    }
+
+    return {
+      directoryName: finalName,
+      friendlyName: input,
+      isNew: true,
+    };
+  }
+
+  /**
+   * Checks if a directory exists, swallowing errors (stat throws on non-existent).
+   */
+  private async directoryExists(name: string): Promise<boolean> {
+    try {
+      return await this.projectRepository.projectExists(name);
+    } catch {
+      return false;
+    }
+  }
+}

--- a/src/data/services/rebuild-index.ts
+++ b/src/data/services/rebuild-index.ts
@@ -1,0 +1,62 @@
+import { MetadataRepository } from "../protocols/metadata-repository.js";
+import { ProjectIndexRepository } from "../protocols/project-index-repository.js";
+import { ProjectRepository } from "../protocols/project-repository.js";
+
+/**
+ * Rebuilds the global project name index from scratch by scanning all project
+ * directories and reading their metadata files.
+ *
+ * This is useful for:
+ * - Recovery if the .index file gets corrupted or deleted
+ * - Migration when backfilling metadata for existing projects
+ * - Ensuring the index is consistent with the filesystem
+ *
+ * For projects without .metadata.json, the directory name is used as the
+ * friendly name (identity mapping).
+ */
+export async function rebuildProjectIndex(
+  projectRepo: ProjectRepository,
+  metadataRepo: MetadataRepository,
+  indexRepo: ProjectIndexRepository
+): Promise<{ total: number; withMetadata: number; withoutMetadata: number }> {
+  const projects = await projectRepo.listProjects();
+
+  const entries: Array<{ friendlyName: string; directoryName: string }> = [];
+  let withMetadata = 0;
+  let withoutMetadata = 0;
+
+  for (const dirName of projects) {
+    try {
+      const metadata = await metadataRepo.readMetadata(dirName);
+      if (metadata) {
+        entries.push({
+          friendlyName: metadata.friendlyName,
+          directoryName: dirName,
+        });
+        withMetadata++;
+      } else {
+        // No metadata — use directory name as friendly name
+        entries.push({
+          friendlyName: dirName,
+          directoryName: dirName,
+        });
+        withoutMetadata++;
+      }
+    } catch {
+      // On error reading metadata, fall back to directory name
+      entries.push({
+        friendlyName: dirName,
+        directoryName: dirName,
+      });
+      withoutMetadata++;
+    }
+  }
+
+  await indexRepo.rebuildIndex(entries);
+
+  return {
+    total: projects.length,
+    withMetadata,
+    withoutMetadata,
+  };
+}

--- a/src/domain/entities/index.ts
+++ b/src/domain/entities/index.ts
@@ -1,4 +1,5 @@
 export * from "./file.js";
 export * from "./project.js";
+export * from "./project-metadata.js";
 export * from "./prompt.js";
 export * from "./history-entry.js";

--- a/src/domain/entities/project-metadata.ts
+++ b/src/domain/entities/project-metadata.ts
@@ -1,0 +1,21 @@
+/**
+ * Metadata stored in .metadata.json within each project directory.
+ */
+export interface ProjectMetadata {
+  /** The original user-provided project name (may contain spaces, special chars) */
+  friendlyName: string;
+  /** The normalized filesystem-safe directory name */
+  directoryName: string;
+  /** ISO 8601 timestamp of when the project was first created */
+  createdAt: string;
+}
+
+/**
+ * Enriched project info returned by list_projects with friendly name support.
+ */
+export interface ProjectInfo {
+  /** The filesystem directory name (primary identifier) */
+  name: string;
+  /** The human-friendly display name */
+  friendlyName: string;
+}

--- a/src/infra/filesystem/repositories/fs-file-repository.ts
+++ b/src/infra/filesystem/repositories/fs-file-repository.ts
@@ -28,7 +28,10 @@ export class FsFileRepository implements FileRepository {
     }
 
     const entries = await fs.readdir(projectPath, { withFileTypes: true });
-    return entries.filter((entry) => entry.isFile()).map((entry) => entry.name);
+    return entries
+      .filter((entry) => entry.isFile())
+      .filter((entry) => !entry.name.startsWith("."))
+      .map((entry) => entry.name);
   }
 
   /**

--- a/src/infra/filesystem/repositories/fs-metadata-repository.ts
+++ b/src/infra/filesystem/repositories/fs-metadata-repository.ts
@@ -1,0 +1,75 @@
+import fs from "fs-extra";
+import path from "path";
+import { MetadataRepository } from "../../../data/protocols/metadata-repository.js";
+import { ProjectMetadata } from "../../../domain/entities/index.js";
+
+const METADATA_FILENAME = ".metadata.json";
+
+/**
+ * Filesystem implementation of the MetadataRepository protocol.
+ * Reads and writes .metadata.json files inside each project directory.
+ */
+export class FsMetadataRepository implements MetadataRepository {
+  constructor(private readonly rootDir: string) {}
+
+  /**
+   * Reads metadata for a project by its directory name.
+   * @returns The metadata, or null if no .metadata.json exists or is invalid.
+   */
+  async readMetadata(directoryName: string): Promise<ProjectMetadata | null> {
+    const metadataPath = path.join(
+      this.rootDir,
+      directoryName,
+      METADATA_FILENAME
+    );
+
+    try {
+      const exists = await fs.pathExists(metadataPath);
+      if (!exists) {
+        return null;
+      }
+
+      const content = await fs.readFile(metadataPath, "utf-8");
+      const parsed = JSON.parse(content);
+
+      // Validate required fields
+      if (
+        typeof parsed.friendlyName !== "string" ||
+        typeof parsed.directoryName !== "string" ||
+        typeof parsed.createdAt !== "string"
+      ) {
+        return null;
+      }
+
+      return {
+        friendlyName: parsed.friendlyName,
+        directoryName: parsed.directoryName,
+        createdAt: parsed.createdAt,
+      };
+    } catch {
+      // Return null for any read/parse errors (corrupt file, permissions, etc.)
+      return null;
+    }
+  }
+
+  /**
+   * Writes metadata for a project by its directory name.
+   * Creates or overwrites the .metadata.json file.
+   */
+  async writeMetadata(
+    directoryName: string,
+    metadata: ProjectMetadata
+  ): Promise<void> {
+    const metadataPath = path.join(
+      this.rootDir,
+      directoryName,
+      METADATA_FILENAME
+    );
+
+    await fs.writeFile(
+      metadataPath,
+      JSON.stringify(metadata, null, 2) + "\n",
+      "utf-8"
+    );
+  }
+}

--- a/src/infra/filesystem/repositories/fs-project-index-repository.ts
+++ b/src/infra/filesystem/repositories/fs-project-index-repository.ts
@@ -1,0 +1,120 @@
+import fs from "fs-extra";
+import path from "path";
+import { LockService } from "../../../data/protocols/lock-service.js";
+import { ProjectIndexRepository } from "../../../data/protocols/project-index-repository.js";
+
+const INDEX_FILENAME = ".index";
+const LOCK_KEY = "project-index";
+
+interface IndexFileContent {
+  version: number;
+  mappings: Record<string, string>;
+}
+
+/**
+ * Filesystem implementation of the ProjectIndexRepository protocol.
+ * Reads and writes a .index JSON file in the memory bank root directory.
+ * Uses file-based locking for concurrent access safety.
+ */
+export class FsProjectIndexRepository implements ProjectIndexRepository {
+  private readonly indexPath: string;
+
+  constructor(
+    private readonly rootDir: string,
+    private readonly lockService: LockService
+  ) {
+    this.indexPath = path.join(rootDir, INDEX_FILENAME);
+  }
+
+  /**
+   * Reads and parses the index file.
+   * Returns empty mappings if the file doesn't exist or is corrupt.
+   */
+  private async readIndex(): Promise<IndexFileContent> {
+    try {
+      const exists = await fs.pathExists(this.indexPath);
+      if (!exists) {
+        return { version: 1, mappings: {} };
+      }
+
+      const content = await fs.readFile(this.indexPath, "utf-8");
+      const parsed = JSON.parse(content);
+
+      if (
+        typeof parsed !== "object" ||
+        parsed === null ||
+        typeof parsed.mappings !== "object"
+      ) {
+        return { version: 1, mappings: {} };
+      }
+
+      return {
+        version: parsed.version ?? 1,
+        mappings: parsed.mappings ?? {},
+      };
+    } catch {
+      return { version: 1, mappings: {} };
+    }
+  }
+
+  /**
+   * Writes the index file atomically.
+   */
+  private async writeIndex(index: IndexFileContent): Promise<void> {
+    await fs.writeFile(
+      this.indexPath,
+      JSON.stringify(index, null, 2) + "\n",
+      "utf-8"
+    );
+  }
+
+  async getDirectoryName(friendlyName: string): Promise<string | null> {
+    const index = await this.readIndex();
+    return index.mappings[friendlyName] ?? null;
+  }
+
+  async setMapping(
+    friendlyName: string,
+    directoryName: string
+  ): Promise<void> {
+    const release = await this.lockService.acquireLock(LOCK_KEY);
+    try {
+      const index = await this.readIndex();
+      index.mappings[friendlyName] = directoryName;
+      await this.writeIndex(index);
+    } finally {
+      await release();
+    }
+  }
+
+  async removeMapping(friendlyName: string): Promise<void> {
+    const release = await this.lockService.acquireLock(LOCK_KEY);
+    try {
+      const index = await this.readIndex();
+      delete index.mappings[friendlyName];
+      await this.writeIndex(index);
+    } finally {
+      await release();
+    }
+  }
+
+  async getAllMappings(): Promise<Record<string, string>> {
+    const index = await this.readIndex();
+    return { ...index.mappings };
+  }
+
+  async rebuildIndex(
+    entries: Array<{ friendlyName: string; directoryName: string }>
+  ): Promise<void> {
+    const release = await this.lockService.acquireLock(LOCK_KEY);
+    try {
+      const mappings: Record<string, string> = {};
+      for (const entry of entries) {
+        mappings[entry.friendlyName] = entry.directoryName;
+      }
+      await this.writeIndex({ version: 1, mappings });
+    } finally {
+      await release();
+    }
+  }
+}

--- a/src/main/factories/controllers/patch/patch-validation-factory.ts
+++ b/src/main/factories/controllers/patch/patch-validation-factory.ts
@@ -17,7 +17,9 @@ const makeValidations = (): Validator[] => {
     // Use StringFieldValidator for content fields to allow empty strings and validate type
     new StringFieldValidator("oldContent"),
     new StringFieldValidator("newContent"),
-    new ParamNameValidator("projectName"),
+    // Note: ParamNameValidator is NOT applied to projectName because
+    // the MCP adapter resolves friendly names to directory names before
+    // the controller receives the request.
     new ParamNameValidator("fileName"),
     new PathSecurityValidator("projectName"),
     new PathSecurityValidator("fileName"),

--- a/src/main/factories/controllers/update/update-validation-factory.ts
+++ b/src/main/factories/controllers/update/update-validation-factory.ts
@@ -12,7 +12,9 @@ const makeValidations = (): Validator[] => {
     new RequiredFieldValidator("projectName"),
     new RequiredFieldValidator("fileName"),
     new RequiredFieldValidator("content"),
-    new ParamNameValidator("projectName"),
+    // Note: ParamNameValidator is NOT applied to projectName because
+    // the MCP adapter resolves friendly names to directory names before
+    // the controller receives the request.
     new ParamNameValidator("fileName"),
     new PathSecurityValidator("projectName"),
     new PathSecurityValidator("fileName"),

--- a/src/main/factories/controllers/write/write-validation-factory.ts
+++ b/src/main/factories/controllers/write/write-validation-factory.ts
@@ -12,7 +12,10 @@ const makeValidations = (): Validator[] => {
     new RequiredFieldValidator("projectName"),
     new RequiredFieldValidator("fileName"),
     new RequiredFieldValidator("content"),
-    new ParamNameValidator("projectName"),
+    // Note: ParamNameValidator is NOT applied to projectName because
+    // the MCP adapter resolves friendly names to directory names before
+    // the controller receives the request. The controller always receives
+    // a normalized, filesystem-safe directory name.
     new ParamNameValidator("fileName"),
     new PathSecurityValidator("projectName"),
     new PathSecurityValidator("fileName"),

--- a/src/main/factories/repositories/metadata-repository-factory.ts
+++ b/src/main/factories/repositories/metadata-repository-factory.ts
@@ -1,0 +1,6 @@
+import { FsMetadataRepository } from "../../../infra/filesystem/repositories/fs-metadata-repository.js";
+import { env } from "../../config/env.js";
+
+export const makeMetadataRepository = (): FsMetadataRepository => {
+  return new FsMetadataRepository(env.rootPath);
+};

--- a/src/main/factories/repositories/project-index-repository-factory.ts
+++ b/src/main/factories/repositories/project-index-repository-factory.ts
@@ -1,0 +1,8 @@
+import { FsProjectIndexRepository } from "../../../infra/filesystem/repositories/fs-project-index-repository.js";
+import { FileLockService } from "../../../infra/filesystem/services/file-lock-service.js";
+import { env } from "../../config/env.js";
+
+export const makeProjectIndexRepository = (): FsProjectIndexRepository => {
+  const lockService = new FileLockService(env.rootPath);
+  return new FsProjectIndexRepository(env.rootPath, lockService);
+};

--- a/src/main/factories/services/project-name-resolver-factory.ts
+++ b/src/main/factories/services/project-name-resolver-factory.ts
@@ -1,0 +1,10 @@
+import { ProjectNameResolver } from "../../../data/services/project-name-resolver.js";
+import { FsProjectRepository } from "../../../infra/filesystem/repositories/fs-project-repository.js";
+import { makeProjectIndexRepository } from "../repositories/project-index-repository-factory.js";
+import { env } from "../../config/env.js";
+
+export const makeProjectNameResolver = (): ProjectNameResolver => {
+  const projectRepository = new FsProjectRepository(env.rootPath);
+  const indexRepository = makeProjectIndexRepository();
+  return new ProjectNameResolver(projectRepository, indexRepository);
+};

--- a/src/main/protocols/mcp/adapters/mcp-project-resolution-adapter.ts
+++ b/src/main/protocols/mcp/adapters/mcp-project-resolution-adapter.ts
@@ -4,17 +4,7 @@ import {
 import { ProjectNameResolverService } from "../../../../data/services/project-name-resolver.js";
 import { MetadataRepository } from "../../../../data/protocols/metadata-repository.js";
 import { ProjectIndexRepository } from "../../../../data/protocols/project-index-repository.js";
-import { MCPRequestHandler } from "./mcp-router-adapter.js";
-
-/**
- * Shape of a tool response from the MCP request adapter.
- * The SDK's ServerResult is a union type, so we define the shape we expect.
- */
-interface ToolResponse {
-  content?: Array<{ type: string; text: string }>;
-  isError?: boolean;
-  [key: string]: unknown;
-}
+import { MCPRequestHandler, ToolResponse } from "./mcp-router-adapter.js";
 
 export type ResolutionMode = "read" | "write";
 

--- a/src/main/protocols/mcp/adapters/mcp-project-resolution-adapter.ts
+++ b/src/main/protocols/mcp/adapters/mcp-project-resolution-adapter.ts
@@ -1,0 +1,164 @@
+import {
+  Request as MCPRequest,
+} from "@modelcontextprotocol/sdk/types.js";
+import { ProjectNameResolverService } from "../../../../data/services/project-name-resolver.js";
+import { MetadataRepository } from "../../../../data/protocols/metadata-repository.js";
+import { ProjectIndexRepository } from "../../../../data/protocols/project-index-repository.js";
+import { MCPRequestHandler } from "./mcp-router-adapter.js";
+
+/**
+ * Shape of a tool response from the MCP request adapter.
+ * The SDK's ServerResult is a union type, so we define the shape we expect.
+ */
+interface ToolResponse {
+  content?: Array<{ type: string; text: string }>;
+  isError?: boolean;
+  [key: string]: unknown;
+}
+
+export type ResolutionMode = "read" | "write";
+
+/**
+ * Wraps an MCP request handler to resolve friendly project names to directory names.
+ *
+ * - "read" mode: resolves projectName to an existing directory name before calling the handler.
+ *   If resolution fails, passes through the original name (lets downstream handle the error).
+ * - "write" mode: resolves for creation (normalizes if new), calls the handler,
+ *   then writes metadata and updates the index for newly created projects.
+ */
+export function withProjectResolution(
+  handlerPromise: Promise<MCPRequestHandler>,
+  resolver: ProjectNameResolverService,
+  metadataRepo: MetadataRepository,
+  indexRepo: ProjectIndexRepository,
+  mode: ResolutionMode
+): Promise<MCPRequestHandler> {
+  return handlerPromise.then((handler) => {
+    return async (request: MCPRequest) => {
+      const args = (request.params?.arguments ?? {}) as Record<
+        string,
+        unknown
+      >;
+
+      if (!args.projectName || typeof args.projectName !== "string") {
+        return handler(request);
+      }
+
+      const originalName = args.projectName;
+
+      if (mode === "write") {
+        return handleWriteMode(
+          request,
+          handler,
+          args,
+          originalName,
+          resolver,
+          metadataRepo,
+          indexRepo
+        );
+      }
+
+      return handleReadMode(request, handler, args, originalName, resolver, metadataRepo, indexRepo);
+    };
+  });
+}
+
+async function handleWriteMode(
+  request: MCPRequest,
+  handler: MCPRequestHandler,
+  args: Record<string, unknown>,
+  originalName: string,
+  resolver: ProjectNameResolverService,
+  metadataRepo: MetadataRepository,
+  indexRepo: ProjectIndexRepository
+) {
+  const result = await resolver.resolveForCreation(originalName);
+
+  const modifiedRequest = createModifiedRequest(
+    request,
+    args,
+    result.directoryName
+  );
+  const response = await handler(modifiedRequest);
+  const toolResponse = response as ToolResponse;
+
+  // After successful write of a new project, write metadata and update index
+  if (result.isNew && !toolResponse.isError) {
+    try {
+      await metadataRepo.writeMetadata(result.directoryName, {
+        friendlyName: result.friendlyName,
+        directoryName: result.directoryName,
+        createdAt: new Date().toISOString(),
+      });
+      await indexRepo.setMapping(result.friendlyName, result.directoryName);
+    } catch {
+      // Metadata/index write failure should not fail the main operation
+    }
+  }
+
+  return response;
+}
+
+async function handleReadMode(
+  request: MCPRequest,
+  handler: MCPRequestHandler,
+  args: Record<string, unknown>,
+  originalName: string,
+  resolver: ProjectNameResolverService,
+  metadataRepo?: MetadataRepository,
+  indexRepo?: ProjectIndexRepository
+) {
+  const resolved = await resolver.resolve(originalName);
+  const directoryName = resolved ?? originalName;
+
+  // Lazy metadata creation: if this project exists but has no metadata,
+  // backfill it with directoryName as friendlyName for gradual migration.
+  if (resolved && metadataRepo && indexRepo) {
+    ensureLazyMetadata(resolved, metadataRepo, indexRepo);
+  }
+
+  if (resolved && resolved !== originalName) {
+    const modifiedRequest = createModifiedRequest(request, args, resolved);
+    return handler(modifiedRequest);
+  }
+
+  return handler(request);
+}
+
+/**
+ * Fire-and-forget: creates metadata for a project that doesn't have any yet.
+ * Does not block the request or propagate errors.
+ */
+function ensureLazyMetadata(
+  directoryName: string,
+  metadataRepo: MetadataRepository,
+  indexRepo: ProjectIndexRepository
+): void {
+  // Run asynchronously without blocking
+  metadataRepo.readMetadata(directoryName).then((existing) => {
+    if (existing !== null) return; // Already has metadata
+    const metadata = {
+      friendlyName: directoryName,
+      directoryName,
+      createdAt: new Date().toISOString(),
+    };
+    return metadataRepo
+      .writeMetadata(directoryName, metadata)
+      .then(() => indexRepo.setMapping(directoryName, directoryName))
+      .catch(() => {}); // Swallow errors — lazy backfill is best-effort
+  }).catch(() => {}); // Swallow errors
+}
+
+function createModifiedRequest(
+  request: MCPRequest,
+  args: Record<string, unknown>,
+  resolvedProjectName: string
+): MCPRequest {
+  return {
+    ...request,
+    params: {
+      ...request.params,
+      arguments: { ...args, projectName: resolvedProjectName },
+    },
+  } as MCPRequest;
+}

--- a/src/main/protocols/mcp/adapters/mcp-router-adapter.ts
+++ b/src/main/protocols/mcp/adapters/mcp-router-adapter.ts
@@ -7,6 +7,17 @@ import {
 
 export type MCPRequestHandler = (request: MCPRequest) => Promise<MCPResponse>;
 
+/**
+ * Shape of a tool response from the MCP request adapter.
+ * The SDK's ServerResult is a union type, so we define the shape we expect
+ * for tool call responses that include content and error status.
+ */
+export interface ToolResponse {
+  content?: Array<{ type: string; text: string }>;
+  isError?: boolean;
+  [key: string]: unknown;
+}
+
 export type MCPRoute = {
   schema: Tool;
   handler: Promise<MCPRequestHandler>;

--- a/src/main/protocols/mcp/app.ts
+++ b/src/main/protocols/mcp/app.ts
@@ -1,5 +1,10 @@
 import { McpServerAdapter } from "./adapters/mcp-server-adapter.js";
 import routes from "./routes.js";
+import { rebuildProjectIndex } from "../../../data/services/rebuild-index.js";
+import { FsProjectRepository } from "../../../infra/filesystem/repositories/fs-project-repository.js";
+import { makeMetadataRepository } from "../../factories/repositories/metadata-repository-factory.js";
+import { makeProjectIndexRepository } from "../../factories/repositories/project-index-repository-factory.js";
+import { env } from "../../config/env.js";
 
 const router = routes();
 const app = new McpServerAdapter(router);
@@ -7,6 +12,16 @@ const app = new McpServerAdapter(router);
 app.register({
   name: "memory-bank",
   version: "1.0.0",
+});
+
+// Rebuild project index on startup to ensure consistency with the filesystem.
+// Runs asynchronously and does not block server startup.
+rebuildProjectIndex(
+  new FsProjectRepository(env.rootPath),
+  makeMetadataRepository(),
+  makeProjectIndexRepository()
+).catch(() => {
+  // Index rebuild failure should not prevent the server from starting
 });
 
 export default app;

--- a/src/main/protocols/mcp/routes.ts
+++ b/src/main/protocols/mcp/routes.ts
@@ -24,19 +24,9 @@ import {
   adaptMcpGetPromptHandler,
 } from "./adapters/mcp-prompt-adapter.js";
 import { withProjectResolution } from "./adapters/mcp-project-resolution-adapter.js";
-import { McpRouterAdapter, MCPRequestHandler } from "./adapters/mcp-router-adapter.js";
+import { McpRouterAdapter, MCPRequestHandler, ToolResponse } from "./adapters/mcp-router-adapter.js";
 import { Request as MCPRequest, ServerResult } from "@modelcontextprotocol/sdk/types.js";
 import { ProjectInfo } from "../../../domain/entities/index.js";
-
-/**
- * Shape of a tool response from the MCP request adapter.
- * The SDK's ServerResult is a union type, so we define the shape we expect.
- */
-interface ToolResponse {
-  content?: Array<{ type: string; text: string }>;
-  isError?: boolean;
-  [key: string]: unknown;
-}
 
 export default () => {
   const router = new McpRouterAdapter();

--- a/src/main/protocols/mcp/routes.ts
+++ b/src/main/protocols/mcp/routes.ts
@@ -15,14 +15,42 @@ import {
   makeGrepFileController,
   makeGrepProjectController,
 } from "../../factories/controllers/index.js";
+import { makeMetadataRepository } from "../../factories/repositories/metadata-repository-factory.js";
+import { makeProjectIndexRepository } from "../../factories/repositories/project-index-repository-factory.js";
+import { makeProjectNameResolver } from "../../factories/services/project-name-resolver-factory.js";
 import { adaptMcpRequestHandler } from "./adapters/mcp-request-adapter.js";
-import { adaptMcpListPromptsHandler, adaptMcpGetPromptHandler } from "./adapters/mcp-prompt-adapter.js";
+import {
+  adaptMcpListPromptsHandler,
+  adaptMcpGetPromptHandler,
+} from "./adapters/mcp-prompt-adapter.js";
+import { withProjectResolution } from "./adapters/mcp-project-resolution-adapter.js";
 import { McpRouterAdapter } from "./adapters/mcp-router-adapter.js";
+import { ProjectInfo } from "../../../domain/entities/index.js";
 
 export default () => {
   const router = new McpRouterAdapter();
 
-  // Tool endpoints
+  // Create shared resolution dependencies (singletons for this router instance)
+  const resolver = makeProjectNameResolver();
+  const metadataRepo = makeMetadataRepository();
+  const indexRepo = makeProjectIndexRepository();
+
+  /**
+   * Helper to wrap a handler with read-mode project name resolution.
+   * Resolves friendly names to directory names before calling the controller.
+   */
+  const withReadResolution = (handler: Promise<ReturnType<typeof adaptMcpRequestHandler> extends Promise<infer R> ? R : never>) =>
+    withProjectResolution(handler as any, resolver, metadataRepo, indexRepo, "read");
+
+  /**
+   * Helper to wrap a handler with write-mode project name resolution.
+   * Resolves + normalizes for creation, writes metadata for new projects.
+   */
+  const withWriteResolution = (handler: Promise<ReturnType<typeof adaptMcpRequestHandler> extends Promise<infer R> ? R : never>) =>
+    withProjectResolution(handler as any, resolver, metadataRepo, indexRepo, "write");
+
+  // ─── Tool endpoints ──────────────────────────────────────────────────
+
   router.setTool({
     schema: {
       name: "list_projects",
@@ -34,7 +62,7 @@ export default () => {
         required: [],
       },
     },
-    handler: adaptMcpRequestHandler(makeListProjectsController()),
+    handler: createEnrichedListProjectsHandler(),
   });
 
   router.setTool({
@@ -53,7 +81,9 @@ export default () => {
         required: ["projectName"],
       },
     },
-    handler: adaptMcpRequestHandler(makeListProjectFilesController()),
+    handler: withReadResolution(
+      adaptMcpRequestHandler(makeListProjectFilesController())
+    ),
   });
 
   router.setTool({
@@ -74,33 +104,40 @@ export default () => {
           },
           includeLineNumbers: {
             type: "boolean",
-            description: "Whether to include line numbers as metadata prefix in the returned content. When enabled, each line is prefixed with its 1-indexed line number followed by a pipe separator (e.g., '1|first line'). Useful for patch operations. Default: true",
+            description:
+              "Whether to include line numbers as metadata prefix in the returned content. When enabled, each line is prefixed with its 1-indexed line number followed by a pipe separator (e.g., '1|first line'). Useful for patch operations. Default: true",
             default: true,
           },
           startLine: {
             type: "integer",
-            description: "First line to read (1-based indexing). When omitted, reading starts from the beginning of the file.",
+            description:
+              "First line to read (1-based indexing). When omitted, reading starts from the beginning of the file.",
           },
           endLine: {
             type: "integer",
-            description: "Last line to read (1-based indexing, inclusive). When omitted, reading continues to the end of the file.",
+            description:
+              "Last line to read (1-based indexing, inclusive). When omitted, reading continues to the end of the file.",
           },
           maxLines: {
             type: "integer",
-            description: "Maximum number of lines to return. When used with startLine, returns up to maxLines starting from startLine. When used alone, returns the first maxLines of the file.",
+            description:
+              "Maximum number of lines to return. When used with startLine, returns up to maxLines starting from startLine. When used alone, returns the first maxLines of the file.",
           },
         },
         required: ["projectName", "fileName"],
       },
     },
-    handler: adaptMcpRequestHandler(makeReadController()),
+    handler: withReadResolution(
+      adaptMcpRequestHandler(makeReadController())
+    ),
   });
 
   router.setTool({
     schema: {
       name: "peek_file",
       title: "Peek Memory Bank File",
-      description: "Quick inspection of a memory bank file. Returns file metadata (total line count) and a preview of the first N lines. Useful for understanding file size and content before reading the full file, preventing context overload with large files.",
+      description:
+        "Quick inspection of a memory bank file. Returns file metadata (total line count) and a preview of the first N lines. Useful for understanding file size and content before reading the full file, preventing context overload with large files.",
       inputSchema: {
         type: "object",
         properties: {
@@ -114,14 +151,17 @@ export default () => {
           },
           previewLines: {
             type: "integer",
-            description: "Number of lines to include in the preview (default: 10)",
+            description:
+              "Number of lines to include in the preview (default: 10)",
             default: 10,
           },
         },
         required: ["projectName", "fileName"],
       },
     },
-    handler: adaptMcpRequestHandler(makePeekController()),
+    handler: withReadResolution(
+      adaptMcpRequestHandler(makePeekController())
+    ),
   });
 
   router.setTool({
@@ -148,14 +188,17 @@ export default () => {
         required: ["projectName", "fileName", "content"],
       },
     },
-    handler: adaptMcpRequestHandler(makeWriteController()),
+    handler: withWriteResolution(
+      adaptMcpRequestHandler(makeWriteController())
+    ),
   });
 
   router.setTool({
     schema: {
       name: "memory_bank_update",
       title: "Update Memory Bank File",
-      description: "Update an existing memory bank file for a specific project",
+      description:
+        "Update an existing memory bank file for a specific project",
       inputSchema: {
         type: "object",
         properties: {
@@ -175,13 +218,16 @@ export default () => {
         required: ["projectName", "fileName", "content"],
       },
     },
-    handler: adaptMcpRequestHandler(makeUpdateController()),
+    handler: withReadResolution(
+      adaptMcpRequestHandler(makeUpdateController())
+    ),
   });
 
   router.setTool({
     schema: {
       name: "memory_bank_delete",
-      description: "Delete a memory bank file by archiving it with a timestamp",
+      description:
+        "Delete a memory bank file by archiving it with a timestamp",
       inputSchema: {
         type: "object",
         properties: {
@@ -197,7 +243,9 @@ export default () => {
         required: ["projectName", "fileName"],
       },
     },
-    handler: adaptMcpRequestHandler(makeDeleteController()),
+    handler: withReadResolution(
+      adaptMcpRequestHandler(makeDeleteController())
+    ),
   });
 
   router.setTool({
@@ -247,14 +295,17 @@ export default () => {
         ],
       },
     },
-    handler: adaptMcpRequestHandler(makePatchController()),
+    handler: withReadResolution(
+      adaptMcpRequestHandler(makePatchController())
+    ),
   });
 
   router.setTool({
     schema: {
       name: "get_project_history",
       title: "Get Project History",
-      description: "Get the change history for all files in a project. Returns metadata (timestamp, action, actor, fileName) for all historical changes without file content for efficient browsing.",
+      description:
+        "Get the change history for all files in a project. Returns metadata (timestamp, action, actor, fileName) for all historical changes without file content for efficient browsing.",
       inputSchema: {
         type: "object",
         properties: {
@@ -266,14 +317,17 @@ export default () => {
         required: ["projectName"],
       },
     },
-    handler: adaptMcpRequestHandler(makeGetProjectHistoryController()),
+    handler: withReadResolution(
+      adaptMcpRequestHandler(makeGetProjectHistoryController())
+    ),
   });
 
   router.setTool({
     schema: {
       name: "get_file_at_time",
       title: "Get File At Time",
-      description: "Retrieve the content of a specific file at a specific point in time. Use this after browsing project history to get the actual content of a file at a particular timestamp.",
+      description:
+        "Retrieve the content of a specific file at a specific point in time. Use this after browsing project history to get the actual content of a file at a particular timestamp.",
       inputSchema: {
         type: "object",
         properties: {
@@ -287,20 +341,24 @@ export default () => {
           },
           timestamp: {
             type: "string",
-            description: "ISO 8601 timestamp to get the file content at (e.g., '2024-01-15T10:30:00.000Z')",
+            description:
+              "ISO 8601 timestamp to get the file content at (e.g., '2024-01-15T10:30:00.000Z')",
           },
         },
         required: ["projectName", "fileName", "timestamp"],
       },
     },
-    handler: adaptMcpRequestHandler(makeGetFileAtTimeController()),
+    handler: withReadResolution(
+      adaptMcpRequestHandler(makeGetFileAtTimeController())
+    ),
   });
 
   router.setTool({
     schema: {
       name: "get_project_file_history_diff",
       title: "Get File History Diff",
-      description: "Generate a unified diff between two versions of a file. Returns standard unified diff format (similar to git diff) showing additions, deletions, and context lines.",
+      description:
+        "Generate a unified diff between two versions of a file. Returns standard unified diff format (similar to git diff) showing additions, deletions, and context lines.",
       inputSchema: {
         type: "object",
         properties: {
@@ -318,13 +376,16 @@ export default () => {
           },
           versionTo: {
             type: "integer",
-            description: "Target version number (1-based, optional - defaults to current/latest version)",
+            description:
+              "Target version number (1-based, optional - defaults to current/latest version)",
           },
         },
         required: ["projectName", "fileName", "versionFrom"],
       },
     },
-    handler: adaptMcpRequestHandler(makeGetFileHistoryDiffController()),
+    handler: withReadResolution(
+      adaptMcpRequestHandler(makeGetFileHistoryDiffController())
+    ),
   });
 
   router.setTool({
@@ -364,7 +425,9 @@ export default () => {
         required: ["projectName", "fileName", "pattern"],
       },
     },
-    handler: adaptMcpRequestHandler(makeGrepFileController()),
+    handler: withReadResolution(
+      adaptMcpRequestHandler(makeGrepFileController())
+    ),
   });
 
   router.setTool({
@@ -406,10 +469,13 @@ export default () => {
         required: ["projectName", "pattern"],
       },
     },
-    handler: adaptMcpRequestHandler(makeGrepProjectController()),
+    handler: withReadResolution(
+      adaptMcpRequestHandler(makeGrepProjectController())
+    ),
   });
 
-  // Prompt endpoints
+  // ─── Prompt endpoints ────────────────────────────────────────────────
+
   router.setPromptListHandler(
     adaptMcpListPromptsHandler(makeListPromptsController())
   );
@@ -419,4 +485,64 @@ export default () => {
   );
 
   return router;
+
+  // ─── Internal helpers ────────────────────────────────────────────────
+
+  /**
+   * Creates an enriched list_projects handler that returns ProjectInfo objects
+   * (with both directory name and friendly name) instead of plain strings.
+   */
+  function createEnrichedListProjectsHandler(): Promise<(request: any) => Promise<any>> {
+    const baseHandler = adaptMcpRequestHandler(makeListProjectsController());
+
+    return baseHandler.then((handler) => {
+      return async (request: any) => {
+        const response = (await handler(request)) as any;
+
+        // If error, pass through
+        if (response.isError) {
+          return response;
+        }
+
+        try {
+          // Parse the original response (JSON array of strings)
+          const text =
+            response.content?.[0]?.type === "text"
+              ? response.content[0].text
+              : null;
+          if (!text) return response;
+
+          const projects: string[] = JSON.parse(text);
+
+          // Enrich each project with friendly name from metadata
+          const enriched: ProjectInfo[] = await Promise.all(
+            projects.map(async (dirName) => {
+              try {
+                const metadata = await metadataRepo.readMetadata(dirName);
+                return {
+                  name: dirName,
+                  friendlyName: metadata?.friendlyName ?? dirName,
+                };
+              } catch {
+                return { name: dirName, friendlyName: dirName };
+              }
+            })
+          );
+
+          return {
+            content: [
+              {
+                type: "text",
+                text: JSON.stringify(enriched, null, 2),
+              },
+            ],
+            isError: false,
+          };
+        } catch {
+          // If enrichment fails, return original response
+          return response;
+        }
+      };
+    });
+  }
 };

--- a/src/web-ui/app/projects/[id]/page.tsx
+++ b/src/web-ui/app/projects/[id]/page.tsx
@@ -114,9 +114,10 @@ export default function ProjectDetailPage() {
     return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + ' ' + sizes[i];
   };
 
+  const displayName = data?.project?.friendlyName || projectName;
   const breadcrumbs = [
     { label: 'Projects', href: '/' },
-    { label: projectName, href: `/projects/${encodeURIComponent(projectName)}` },
+    { label: displayName, href: `/projects/${encodeURIComponent(projectName)}` },
   ];
 
   if (loading) {
@@ -178,9 +179,14 @@ export default function ProjectDetailPage() {
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
           <div className="flex items-start justify-between">
             <div>
-              <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">
-                {data.project.name}
+              <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-1">
+                {data.project.friendlyName || data.project.name}
               </h1>
+              {data.project.friendlyName && data.project.friendlyName !== data.project.name && (
+                <p className="text-sm text-gray-400 dark:text-gray-500 mb-1">
+                  {data.project.name}
+                </p>
+              )}
               {data.project.description && (
                 <p className="text-gray-600 dark:text-gray-400 mb-4">
                   {data.project.description}

--- a/src/web-ui/components/ProjectList.tsx
+++ b/src/web-ui/components/ProjectList.tsx
@@ -17,13 +17,14 @@ export default function ProjectList({ projects, loading, onProjectArchived }: Pr
   const [archiveConfirm, setArchiveConfirm] = useState<string | null>(null);
   const [archiving, setArchiving] = useState<string | null>(null);
 
-  // Filter projects based on search term
+  // Filter projects based on search term (searches name, friendlyName, and description)
   const filteredProjects = useMemo(() => {
     if (!searchTerm.trim()) return projects;
     
     const term = searchTerm.toLowerCase();
     return projects.filter(project =>
       project.name.toLowerCase().includes(term) ||
+      (project.friendlyName && project.friendlyName.toLowerCase().includes(term)) ||
       (project.description && project.description.toLowerCase().includes(term))
     );
   }, [projects, searchTerm]);
@@ -263,11 +264,19 @@ export default function ProjectList({ projects, loading, onProjectArchived }: Pr
                         <ClipboardIcon className="w-4 h-4" />
                       )}
                     </button>
-                    <h3 className="text-lg font-semibold text-gray-900 dark:text-white 
-                                 group-hover:text-blue-600 dark:group-hover:text-blue-400 
-                                 transition-colors line-clamp-2 flex-1">
-                      {project.name}
-                    </h3>
+                    <div className="flex-1 min-w-0">
+                      <h3 className="text-lg font-semibold text-gray-900 dark:text-white 
+                                   group-hover:text-blue-600 dark:group-hover:text-blue-400 
+                                   transition-colors line-clamp-2">
+                        {project.friendlyName || project.name}
+                      </h3>
+                      {project.friendlyName && project.friendlyName !== project.name && (
+                        <p className="text-xs text-gray-400 dark:text-gray-500 mt-0.5 truncate"
+                           title={project.name}>
+                          {project.name}
+                        </p>
+                      )}
+                    </div>
                   </div>
                   <DocumentTextIcon className="w-5 h-5 text-gray-400 group-hover:text-blue-500 
                                              transition-colors flex-shrink-0 ml-2" />

--- a/src/web-ui/test/components/ProjectList.test.tsx
+++ b/src/web-ui/test/components/ProjectList.test.tsx
@@ -17,23 +17,27 @@ twoWeeksAgo.setDate(twoWeeksAgo.getDate() - 14);
 const mockProjects: ProjectInfo[] = [
   {
     name: 'Test Project 1',
+    friendlyName: 'Test Project 1',
     description: 'A test project for memory bank',
     lastModified: today,
     fileCount: 5,
   },
   {
     name: 'Another Project',
+    friendlyName: 'Another Project',
     description: 'Another project for testing',
     lastModified: yesterday,
     fileCount: 3,
   },
   {
     name: 'API Documentation',
+    friendlyName: 'API Documentation',
     lastModified: lastWeek,
     fileCount: 10,
   },
   {
     name: 'Old Project',
+    friendlyName: 'Old Project',
     description: 'Project from two weeks ago',
     lastModified: twoWeeksAgo,
     fileCount: 2,

--- a/tests/data/helpers/normalize-project-name.test.ts
+++ b/tests/data/helpers/normalize-project-name.test.ts
@@ -152,6 +152,18 @@ describe("normalizeProjectName", () => {
     it("should remove trailing dots", () => {
       expect(normalizeProjectName("my-project.")).toBe("my-project");
     });
+
+    it("should remove multiple leading hyphens and dots", () => {
+      expect(normalizeProjectName("--..my-project")).toBe("my-project");
+    });
+
+    it("should remove multiple trailing hyphens and dots", () => {
+      expect(normalizeProjectName("my-project.-.-")).toBe("my-project");
+    });
+
+    it("should handle alternating leading special chars like -.foo", () => {
+      expect(normalizeProjectName("-.foo")).toBe("foo");
+    });
   });
 
   describe("length constraints", () => {

--- a/tests/data/helpers/normalize-project-name.test.ts
+++ b/tests/data/helpers/normalize-project-name.test.ts
@@ -116,6 +116,18 @@ describe("normalizeProjectName", () => {
     it("should handle emoji by stripping them", () => {
       expect(normalizeProjectName("🚀 My Project")).toBe("my-project");
     });
+
+    it("should transliterate NFD-encoded umlauts (e.g. macOS decomposed forms)", () => {
+      // NFD: u + combining diaeresis (U+0308) instead of precomposed ü (U+00FC)
+      const nfdUber = "U\u0308ber Projekt";
+      expect(normalizeProjectName(nfdUber)).toBe("ueber-projekt");
+    });
+
+    it("should produce the same result for NFC and NFD input", () => {
+      const nfc = "\u00FC"; // ü precomposed
+      const nfd = "u\u0308"; // u + combining diaeresis
+      expect(normalizeProjectName(nfc)).toBe(normalizeProjectName(nfd));
+    });
   });
 
   describe("consecutive separators", () => {

--- a/tests/data/helpers/normalize-project-name.test.ts
+++ b/tests/data/helpers/normalize-project-name.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from "vitest";
+import { normalizeProjectName } from "../../../src/data/helpers/normalize-project-name.js";
+
+describe("normalizeProjectName", () => {
+  describe("basic normalization", () => {
+    it("should convert spaces to hyphens", () => {
+      expect(normalizeProjectName("My Cool Project")).toBe("my-cool-project");
+    });
+
+    it("should convert to lowercase", () => {
+      expect(normalizeProjectName("MyProject")).toBe("myproject");
+    });
+
+    it("should trim whitespace", () => {
+      expect(normalizeProjectName("  my-project  ")).toBe("my-project");
+    });
+
+    it("should convert underscores to hyphens", () => {
+      expect(normalizeProjectName("my_cool_project")).toBe("my-cool-project");
+    });
+
+    it("should keep existing hyphens", () => {
+      expect(normalizeProjectName("my-project")).toBe("my-project");
+    });
+
+    it("should keep dots", () => {
+      expect(normalizeProjectName("my.project")).toBe("my.project");
+    });
+
+    it("should keep numbers", () => {
+      expect(normalizeProjectName("project-123")).toBe("project-123");
+    });
+
+    it("should pass through already-normalized names unchanged", () => {
+      expect(normalizeProjectName("my-cool-project")).toBe("my-cool-project");
+    });
+  });
+
+  describe("special characters", () => {
+    it("should remove exclamation marks", () => {
+      expect(normalizeProjectName("My Project!")).toBe("my-project");
+    });
+
+    it("should remove at signs", () => {
+      expect(normalizeProjectName("my@project")).toBe("myproject");
+    });
+
+    it("should remove hash symbols", () => {
+      expect(normalizeProjectName("project#1")).toBe("project1");
+    });
+
+    it("should remove dollar signs", () => {
+      expect(normalizeProjectName("$project")).toBe("project");
+    });
+
+    it("should remove percent signs", () => {
+      expect(normalizeProjectName("100% project")).toBe("100-project");
+    });
+
+    it("should remove ampersands", () => {
+      expect(normalizeProjectName("cats & dogs")).toBe("cats-dogs");
+    });
+
+    it("should remove parentheses", () => {
+      expect(normalizeProjectName("project (v2)")).toBe("project-v2");
+    });
+
+    it("should remove colons", () => {
+      expect(normalizeProjectName("project: the sequel")).toBe(
+        "project-the-sequel"
+      );
+    });
+
+    it("should remove forward slashes", () => {
+      expect(normalizeProjectName("frontend/backend")).toBe(
+        "frontendbackend"
+      );
+    });
+
+    it("should remove backslashes", () => {
+      expect(normalizeProjectName("front\\back")).toBe("frontback");
+    });
+
+    it("should handle mixed special characters", () => {
+      expect(normalizeProjectName("My (Cool) Project! #1")).toBe(
+        "my-cool-project-1"
+      );
+    });
+  });
+
+  describe("unicode/international characters", () => {
+    it("should transliterate German umlauts", () => {
+      expect(normalizeProjectName("Über Projekt")).toBe("ueber-projekt");
+    });
+
+    it("should transliterate French accents", () => {
+      expect(normalizeProjectName("café résumé")).toBe("cafe-resume");
+    });
+
+    it("should transliterate Spanish ñ", () => {
+      expect(normalizeProjectName("España")).toBe("espana");
+    });
+
+    it("should transliterate Nordic characters", () => {
+      expect(normalizeProjectName("smörgåsbord")).toBe("smoergasbord");
+    });
+
+    it("should transliterate German ß", () => {
+      expect(normalizeProjectName("Straße")).toBe("strasse");
+    });
+
+    it("should strip non-transliterable unicode characters", () => {
+      expect(normalizeProjectName("项目 project")).toBe("project");
+    });
+
+    it("should handle emoji by stripping them", () => {
+      expect(normalizeProjectName("🚀 My Project")).toBe("my-project");
+    });
+  });
+
+  describe("consecutive separators", () => {
+    it("should collapse multiple spaces into single hyphen", () => {
+      expect(normalizeProjectName("my   project")).toBe("my-project");
+    });
+
+    it("should collapse multiple hyphens into one", () => {
+      expect(normalizeProjectName("my---project")).toBe("my-project");
+    });
+
+    it("should collapse multiple dots into one", () => {
+      expect(normalizeProjectName("my...project")).toBe("my.project");
+    });
+
+    it("should collapse hyphens resulting from special char removal", () => {
+      expect(normalizeProjectName("a - - b")).toBe("a-b");
+    });
+  });
+
+  describe("leading/trailing cleanup", () => {
+    it("should remove leading hyphens", () => {
+      expect(normalizeProjectName("-my-project")).toBe("my-project");
+    });
+
+    it("should remove trailing hyphens", () => {
+      expect(normalizeProjectName("my-project-")).toBe("my-project");
+    });
+
+    it("should remove leading dots", () => {
+      expect(normalizeProjectName(".my-project")).toBe("my-project");
+    });
+
+    it("should remove trailing dots", () => {
+      expect(normalizeProjectName("my-project.")).toBe("my-project");
+    });
+  });
+
+  describe("length constraints", () => {
+    it("should truncate names exceeding max length", () => {
+      const longName = "a".repeat(300);
+      const result = normalizeProjectName(longName);
+      expect(result.length).toBeLessThanOrEqual(200);
+    });
+
+    it("should clean trailing hyphens after truncation", () => {
+      // Create a name that will have a hyphen right at the truncation point
+      const name = "a".repeat(199) + "-b";
+      const result = normalizeProjectName(name);
+      expect(result).not.toMatch(/[-.]$/);
+    });
+  });
+
+  describe("error cases", () => {
+    it("should throw on empty string", () => {
+      expect(() => normalizeProjectName("")).toThrow(
+        "Project name cannot be empty"
+      );
+    });
+
+    it("should throw on whitespace-only string", () => {
+      expect(() => normalizeProjectName("   ")).toThrow(
+        "Project name cannot be empty"
+      );
+    });
+
+    it("should throw when name normalizes to empty string", () => {
+      expect(() => normalizeProjectName("!!!")).toThrow(
+        'Project name "!!!" cannot be normalized to a valid directory name'
+      );
+    });
+
+    it("should throw when name is only special characters", () => {
+      expect(() => normalizeProjectName("@#$%^&")).toThrow(
+        "cannot be normalized"
+      );
+    });
+
+    it("should throw when name is only unicode with no transliteration", () => {
+      expect(() => normalizeProjectName("中文项目")).toThrow(
+        "cannot be normalized"
+      );
+    });
+  });
+
+  describe("real-world project names", () => {
+    it("should handle typical project names with spaces", () => {
+      expect(normalizeProjectName("My Memory Bank")).toBe("my-memory-bank");
+    });
+
+    it("should handle names with version numbers", () => {
+      expect(normalizeProjectName("Project v2.0")).toBe("project-v2.0");
+    });
+
+    it("should handle names with organization prefixes", () => {
+      expect(normalizeProjectName("Acme Corp - Widget Builder")).toBe(
+        "acme-corp-widget-builder"
+      );
+    });
+
+    it("should handle camelCase names", () => {
+      expect(normalizeProjectName("myProject")).toBe("myproject");
+    });
+
+    it("should handle names that are already filesystem-safe", () => {
+      expect(normalizeProjectName("already-safe-name")).toBe(
+        "already-safe-name"
+      );
+    });
+
+    it("should handle single character names", () => {
+      expect(normalizeProjectName("a")).toBe("a");
+    });
+
+    it("should handle numeric names", () => {
+      expect(normalizeProjectName("12345")).toBe("12345");
+    });
+  });
+});

--- a/tests/data/services/project-name-resolver.test.ts
+++ b/tests/data/services/project-name-resolver.test.ts
@@ -1,0 +1,245 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ProjectNameResolver,
+  ProjectNameResolverService,
+} from "../../../src/data/services/project-name-resolver.js";
+import { ProjectRepository } from "../../../src/data/protocols/project-repository.js";
+import { ProjectIndexRepository } from "../../../src/data/protocols/project-index-repository.js";
+
+// --- Mock implementations ---
+
+class MockProjectRepository implements ProjectRepository {
+  private projects = new Set<string>();
+
+  addProject(name: string) {
+    this.projects.add(name);
+  }
+
+  async listProjects(): Promise<string[]> {
+    return Array.from(this.projects);
+  }
+
+  async projectExists(name: string): Promise<boolean> {
+    if (!this.projects.has(name)) {
+      throw new Error("ENOENT");
+    }
+    return true;
+  }
+
+  async ensureProject(name: string): Promise<void> {
+    this.projects.add(name);
+  }
+}
+
+class MockIndexRepository implements ProjectIndexRepository {
+  private mappings: Record<string, string> = {};
+
+  async getDirectoryName(friendlyName: string): Promise<string | null> {
+    return this.mappings[friendlyName] ?? null;
+  }
+
+  async setMapping(
+    friendlyName: string,
+    directoryName: string
+  ): Promise<void> {
+    this.mappings[friendlyName] = directoryName;
+  }
+
+  async removeMapping(friendlyName: string): Promise<void> {
+    delete this.mappings[friendlyName];
+  }
+
+  async getAllMappings(): Promise<Record<string, string>> {
+    return { ...this.mappings };
+  }
+
+  async rebuildIndex(
+    entries: Array<{ friendlyName: string; directoryName: string }>
+  ): Promise<void> {
+    this.mappings = {};
+    for (const e of entries) {
+      this.mappings[e.friendlyName] = e.directoryName;
+    }
+  }
+}
+
+describe("ProjectNameResolver", () => {
+  let projectRepo: MockProjectRepository;
+  let indexRepo: MockIndexRepository;
+  let resolver: ProjectNameResolverService;
+
+  beforeEach(() => {
+    projectRepo = new MockProjectRepository();
+    indexRepo = new MockIndexRepository();
+    resolver = new ProjectNameResolver(projectRepo, indexRepo);
+  });
+
+  describe("resolve", () => {
+    it("should return the input when it matches an existing directory", async () => {
+      projectRepo.addProject("my-project");
+      const result = await resolver.resolve("my-project");
+      expect(result).toBe("my-project");
+    });
+
+    it("should resolve via index when input is a known friendly name", async () => {
+      projectRepo.addProject("my-cool-project");
+      await indexRepo.setMapping("My Cool Project", "my-cool-project");
+
+      const result = await resolver.resolve("My Cool Project");
+      expect(result).toBe("my-cool-project");
+    });
+
+    it("should resolve via normalization when input normalizes to existing directory", async () => {
+      projectRepo.addProject("my-cool-project");
+      // No index entry, but normalization of "My Cool Project" = "my-cool-project"
+      const result = await resolver.resolve("My Cool Project");
+      expect(result).toBe("my-cool-project");
+    });
+
+    it("should return null when no matching project exists", async () => {
+      const result = await resolver.resolve("Nonexistent Project");
+      expect(result).toBeNull();
+    });
+
+    it("should return null when normalized name does not match any directory", async () => {
+      projectRepo.addProject("other-project");
+      const result = await resolver.resolve("My Missing Project");
+      expect(result).toBeNull();
+    });
+
+    it("should prefer exact directory match over index lookup", async () => {
+      // "My Cool Project" is both a directory name AND a friendly name pointing elsewhere
+      projectRepo.addProject("My Cool Project");
+      projectRepo.addProject("other-dir");
+      await indexRepo.setMapping("My Cool Project", "other-dir");
+
+      const result = await resolver.resolve("My Cool Project");
+      expect(result).toBe("My Cool Project");
+    });
+
+    it("should handle index mapping to a deleted directory gracefully", async () => {
+      // Index points to a directory that no longer exists
+      await indexRepo.setMapping("My Project", "deleted-dir");
+      // But the normalized name also doesn't exist
+      const result = await resolver.resolve("My Project");
+      expect(result).toBeNull();
+    });
+
+    it("should handle names that cannot be normalized", async () => {
+      // "!!!" cannot be normalized (all special chars)
+      const result = await resolver.resolve("!!!");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("resolveForCreation", () => {
+    it("should return existing project when it exists by directory name", async () => {
+      projectRepo.addProject("my-project");
+      const result = await resolver.resolveForCreation("my-project");
+      expect(result).toEqual({
+        directoryName: "my-project",
+        friendlyName: "my-project",
+        isNew: false,
+      });
+    });
+
+    it("should return existing project when it exists by friendly name in index", async () => {
+      projectRepo.addProject("my-cool-project");
+      await indexRepo.setMapping("My Cool Project", "my-cool-project");
+
+      const result = await resolver.resolveForCreation("My Cool Project");
+      expect(result).toEqual({
+        directoryName: "my-cool-project",
+        friendlyName: "My Cool Project",
+        isNew: false,
+      });
+    });
+
+    it("should return existing project when normalization matches", async () => {
+      projectRepo.addProject("my-cool-project");
+
+      const result = await resolver.resolveForCreation("My Cool Project");
+      expect(result).toEqual({
+        directoryName: "my-cool-project",
+        friendlyName: "My Cool Project",
+        isNew: false,
+      });
+    });
+
+    it("should create new project with normalized name", async () => {
+      const result = await resolver.resolveForCreation("My New Project!");
+      expect(result).toEqual({
+        directoryName: "my-new-project",
+        friendlyName: "My New Project!",
+        isNew: true,
+      });
+    });
+
+    it("should handle collision by appending suffix", async () => {
+      // "my-project" directory exists but is NOT mapped to "My Project" in the index
+      // AND is NOT the normalization of "My Project" — wait, it IS.
+      // Let me set up a proper collision:
+      // "my-project" exists and IS the normalization of "My Project"
+      // So resolveForCreation should find it via resolve() step 3
+
+      // Instead, test a true collision:
+      // "test-project" exists (legacy)
+      projectRepo.addProject("test-project");
+      // The index has "test-project" mapped to a DIFFERENT friendly name
+      await indexRepo.setMapping("Original Name", "test-project");
+
+      // Now someone tries to create "Test Project" which normalizes to "test-project"
+      // resolve() step 1: "Test Project" is not a directory ✗
+      // resolve() step 2: "Test Project" not in index ✗
+      // resolve() step 3: normalize("Test Project") = "test-project", exists ✓
+      // So it returns existing project
+      const result = await resolver.resolveForCreation("Test Project");
+      expect(result).toEqual({
+        directoryName: "test-project",
+        friendlyName: "Test Project",
+        isNew: false,
+      });
+    });
+
+    it("should append suffix when normalized name collides and resolve does not match", async () => {
+      // This scenario: resolve() returns existing, so collision suffix not needed
+      // To truly test suffix: we need resolve() to return null, but normalized dir exists
+      // That can't happen in normal flow because resolve() step 3 checks normalized.
+      // The suffix logic handles an edge case where resolve returns null
+      // but the directory gets created between resolve() and the existence check.
+      // For unit testing, let's mock the behavior:
+
+      // Create a resolver where resolve returns null but the dir exists
+      const specialProjectRepo = new MockProjectRepository();
+      const specialIndexRepo = new MockIndexRepository();
+      const specialResolver = new ProjectNameResolver(
+        specialProjectRepo,
+        specialIndexRepo
+      );
+
+      // Make "test-project" exist AFTER resolve() runs
+      // We can achieve this by spying on resolve
+      vi.spyOn(specialResolver, "resolve").mockResolvedValueOnce(null);
+      specialProjectRepo.addProject("test-project"); // Exists for collision check
+
+      const result = await specialResolver.resolveForCreation("Test Project");
+      expect(result.directoryName).toBe("test-project-1");
+      expect(result.isNew).toBe(true);
+    });
+
+    it("should throw when name cannot be normalized at all", async () => {
+      await expect(resolver.resolveForCreation("!!!")).rejects.toThrow(
+        "cannot be normalized"
+      );
+    });
+
+    it("should handle names that are already filesystem-safe", async () => {
+      const result = await resolver.resolveForCreation("my-safe-name");
+      expect(result).toEqual({
+        directoryName: "my-safe-name",
+        friendlyName: "my-safe-name",
+        isNew: true,
+      });
+    });
+  });
+});

--- a/tests/data/services/rebuild-index.test.ts
+++ b/tests/data/services/rebuild-index.test.ts
@@ -1,0 +1,164 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { rebuildProjectIndex } from "../../../src/data/services/rebuild-index.js";
+import { ProjectRepository } from "../../../src/data/protocols/project-repository.js";
+import { MetadataRepository } from "../../../src/data/protocols/metadata-repository.js";
+import { ProjectIndexRepository } from "../../../src/data/protocols/project-index-repository.js";
+import { ProjectMetadata } from "../../../src/domain/entities/index.js";
+
+// --- Mocks ---
+
+const makeProjectRepo = (projects: string[]): ProjectRepository => ({
+  listProjects: vi.fn().mockResolvedValue(projects),
+  projectExists: vi.fn().mockResolvedValue(true),
+  ensureProject: vi.fn().mockResolvedValue(undefined),
+});
+
+const makeMetadataRepo = (
+  metadataMap: Record<string, ProjectMetadata | null>
+): MetadataRepository => ({
+  readMetadata: vi.fn().mockImplementation(async (dirName: string) => {
+    return metadataMap[dirName] ?? null;
+  }),
+  writeMetadata: vi.fn().mockResolvedValue(undefined),
+});
+
+const makeIndexRepo = (): ProjectIndexRepository => ({
+  getDirectoryName: vi.fn().mockResolvedValue(null),
+  setMapping: vi.fn().mockResolvedValue(undefined),
+  removeMapping: vi.fn().mockResolvedValue(undefined),
+  getAllMappings: vi.fn().mockResolvedValue({}),
+  rebuildIndex: vi.fn().mockResolvedValue(undefined),
+});
+
+describe("rebuildProjectIndex", () => {
+  it("should rebuild index with metadata from all projects", async () => {
+    const projectRepo = makeProjectRepo([
+      "my-cool-project",
+      "another-project",
+    ]);
+    const metadataRepo = makeMetadataRepo({
+      "my-cool-project": {
+        friendlyName: "My Cool Project",
+        directoryName: "my-cool-project",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+      "another-project": {
+        friendlyName: "Another Project",
+        directoryName: "another-project",
+        createdAt: "2026-01-02T00:00:00.000Z",
+      },
+    });
+    const indexRepo = makeIndexRepo();
+
+    const result = await rebuildProjectIndex(
+      projectRepo,
+      metadataRepo,
+      indexRepo
+    );
+
+    expect(result).toEqual({
+      total: 2,
+      withMetadata: 2,
+      withoutMetadata: 0,
+    });
+
+    expect(indexRepo.rebuildIndex).toHaveBeenCalledWith([
+      {
+        friendlyName: "My Cool Project",
+        directoryName: "my-cool-project",
+      },
+      {
+        friendlyName: "Another Project",
+        directoryName: "another-project",
+      },
+    ]);
+  });
+
+  it("should use directory name as friendly name for projects without metadata", async () => {
+    const projectRepo = makeProjectRepo([
+      "with-metadata",
+      "legacy-project",
+    ]);
+    const metadataRepo = makeMetadataRepo({
+      "with-metadata": {
+        friendlyName: "With Metadata",
+        directoryName: "with-metadata",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    });
+    const indexRepo = makeIndexRepo();
+
+    const result = await rebuildProjectIndex(
+      projectRepo,
+      metadataRepo,
+      indexRepo
+    );
+
+    expect(result).toEqual({
+      total: 2,
+      withMetadata: 1,
+      withoutMetadata: 1,
+    });
+
+    expect(indexRepo.rebuildIndex).toHaveBeenCalledWith([
+      {
+        friendlyName: "With Metadata",
+        directoryName: "with-metadata",
+      },
+      {
+        friendlyName: "legacy-project",
+        directoryName: "legacy-project",
+      },
+    ]);
+  });
+
+  it("should handle empty project list", async () => {
+    const projectRepo = makeProjectRepo([]);
+    const metadataRepo = makeMetadataRepo({});
+    const indexRepo = makeIndexRepo();
+
+    const result = await rebuildProjectIndex(
+      projectRepo,
+      metadataRepo,
+      indexRepo
+    );
+
+    expect(result).toEqual({
+      total: 0,
+      withMetadata: 0,
+      withoutMetadata: 0,
+    });
+    expect(indexRepo.rebuildIndex).toHaveBeenCalledWith([]);
+  });
+
+  it("should handle metadata read errors gracefully", async () => {
+    const projectRepo = makeProjectRepo(["error-project", "ok-project"]);
+    const metadataRepo: MetadataRepository = {
+      readMetadata: vi.fn().mockImplementation(async (dirName: string) => {
+        if (dirName === "error-project") {
+          throw new Error("read error");
+        }
+        return null;
+      }),
+      writeMetadata: vi.fn(),
+    };
+    const indexRepo = makeIndexRepo();
+
+    const result = await rebuildProjectIndex(
+      projectRepo,
+      metadataRepo,
+      indexRepo
+    );
+
+    expect(result).toEqual({
+      total: 2,
+      withMetadata: 0,
+      withoutMetadata: 2,
+    });
+
+    expect(indexRepo.rebuildIndex).toHaveBeenCalledWith([
+      { friendlyName: "error-project", directoryName: "error-project" },
+      { friendlyName: "ok-project", directoryName: "ok-project" },
+    ]);
+  });
+});

--- a/tests/infra/filesystem/repositories/fs-file-repository.test.ts
+++ b/tests/infra/filesystem/repositories/fs-file-repository.test.ts
@@ -48,6 +48,23 @@ describe("FsFileRepository", () => {
       expect(result).toHaveLength(2);
       expect(result).toEqual(expect.arrayContaining(["file1.md", "file2.txt"]));
     });
+
+    it("should exclude dot-prefixed files like .metadata.json", async () => {
+      await fs.writeFile(path.join(tempDir, projectName, "file1.md"), "test");
+      await fs.writeFile(
+        path.join(tempDir, projectName, ".metadata.json"),
+        '{"friendlyName":"test"}'
+      );
+      await fs.writeFile(
+        path.join(tempDir, projectName, ".index"),
+        "{}"
+      );
+
+      const result = await repository.listFiles(projectName);
+
+      expect(result).toHaveLength(1);
+      expect(result).toEqual(["file1.md"]);
+    });
   });
 
   describe("loadFile", () => {

--- a/tests/infra/filesystem/repositories/fs-metadata-repository.test.ts
+++ b/tests/infra/filesystem/repositories/fs-metadata-repository.test.ts
@@ -1,0 +1,137 @@
+import fs from "fs-extra";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { FsMetadataRepository } from "../../../../src/infra/filesystem/repositories/fs-metadata-repository.js";
+import { ProjectMetadata } from "../../../../src/domain/entities/index.js";
+
+describe("FsMetadataRepository", () => {
+  let tempDir: string;
+  let repository: FsMetadataRepository;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "memory-bank-meta-test-"));
+    repository = new FsMetadataRepository(tempDir);
+  });
+
+  afterEach(() => {
+    fs.removeSync(tempDir);
+  });
+
+  const sampleMetadata: ProjectMetadata = {
+    friendlyName: "My Cool Project",
+    directoryName: "my-cool-project",
+    createdAt: "2026-01-15T10:30:00.000Z",
+  };
+
+  describe("readMetadata", () => {
+    it("should return null when project directory does not exist", async () => {
+      const result = await repository.readMetadata("nonexistent");
+      expect(result).toBeNull();
+    });
+
+    it("should return null when .metadata.json does not exist", async () => {
+      await fs.mkdir(path.join(tempDir, "my-project"));
+      const result = await repository.readMetadata("my-project");
+      expect(result).toBeNull();
+    });
+
+    it("should return null when .metadata.json is invalid JSON", async () => {
+      const projectDir = path.join(tempDir, "my-project");
+      await fs.mkdir(projectDir);
+      await fs.writeFile(
+        path.join(projectDir, ".metadata.json"),
+        "not valid json"
+      );
+      const result = await repository.readMetadata("my-project");
+      expect(result).toBeNull();
+    });
+
+    it("should return null when .metadata.json is missing required fields", async () => {
+      const projectDir = path.join(tempDir, "my-project");
+      await fs.mkdir(projectDir);
+      await fs.writeFile(
+        path.join(projectDir, ".metadata.json"),
+        JSON.stringify({ friendlyName: "test" })
+      );
+      const result = await repository.readMetadata("my-project");
+      expect(result).toBeNull();
+    });
+
+    it("should return metadata when .metadata.json is valid", async () => {
+      const projectDir = path.join(tempDir, "my-cool-project");
+      await fs.mkdir(projectDir);
+      await fs.writeFile(
+        path.join(projectDir, ".metadata.json"),
+        JSON.stringify(sampleMetadata)
+      );
+
+      const result = await repository.readMetadata("my-cool-project");
+      expect(result).toEqual(sampleMetadata);
+    });
+
+    it("should ignore extra fields in .metadata.json", async () => {
+      const projectDir = path.join(tempDir, "my-project");
+      await fs.mkdir(projectDir);
+      await fs.writeFile(
+        path.join(projectDir, ".metadata.json"),
+        JSON.stringify({
+          ...sampleMetadata,
+          extraField: "should be ignored",
+          tags: ["a", "b"],
+        })
+      );
+
+      const result = await repository.readMetadata("my-project");
+      expect(result).toEqual(sampleMetadata);
+    });
+  });
+
+  describe("writeMetadata", () => {
+    it("should create .metadata.json in the project directory", async () => {
+      const projectDir = path.join(tempDir, "my-cool-project");
+      await fs.mkdir(projectDir);
+
+      await repository.writeMetadata("my-cool-project", sampleMetadata);
+
+      const metadataPath = path.join(projectDir, ".metadata.json");
+      const exists = await fs.pathExists(metadataPath);
+      expect(exists).toBe(true);
+
+      const content = await fs.readFile(metadataPath, "utf-8");
+      const parsed = JSON.parse(content);
+      expect(parsed).toEqual(sampleMetadata);
+    });
+
+    it("should overwrite existing .metadata.json", async () => {
+      const projectDir = path.join(tempDir, "my-project");
+      await fs.mkdir(projectDir);
+
+      const initialMetadata: ProjectMetadata = {
+        friendlyName: "Old Name",
+        directoryName: "my-project",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      };
+      await repository.writeMetadata("my-project", initialMetadata);
+
+      const updatedMetadata: ProjectMetadata = {
+        friendlyName: "New Name",
+        directoryName: "my-project",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      };
+      await repository.writeMetadata("my-project", updatedMetadata);
+
+      const result = await repository.readMetadata("my-project");
+      expect(result).toEqual(updatedMetadata);
+    });
+
+    it("should produce valid JSON that can be read back", async () => {
+      const projectDir = path.join(tempDir, "my-cool-project");
+      await fs.mkdir(projectDir);
+
+      await repository.writeMetadata("my-cool-project", sampleMetadata);
+      const result = await repository.readMetadata("my-cool-project");
+      expect(result).toEqual(sampleMetadata);
+    });
+  });
+});

--- a/tests/infra/filesystem/repositories/fs-project-index-repository.test.ts
+++ b/tests/infra/filesystem/repositories/fs-project-index-repository.test.ts
@@ -1,0 +1,187 @@
+import fs from "fs-extra";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { FsProjectIndexRepository } from "../../../../src/infra/filesystem/repositories/fs-project-index-repository.js";
+import { FileLockService } from "../../../../src/infra/filesystem/services/file-lock-service.js";
+
+describe("FsProjectIndexRepository", () => {
+  let tempDir: string;
+  let repository: FsProjectIndexRepository;
+  let lockService: FileLockService;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "memory-bank-index-test-"));
+    lockService = new FileLockService(tempDir);
+    repository = new FsProjectIndexRepository(tempDir, lockService);
+  });
+
+  afterEach(() => {
+    fs.removeSync(tempDir);
+  });
+
+  describe("getDirectoryName", () => {
+    it("should return null when index file does not exist", async () => {
+      const result = await repository.getDirectoryName("My Project");
+      expect(result).toBeNull();
+    });
+
+    it("should return null when friendly name is not in index", async () => {
+      await repository.setMapping("Other Project", "other-project");
+      const result = await repository.getDirectoryName("My Project");
+      expect(result).toBeNull();
+    });
+
+    it("should return directory name for a known friendly name", async () => {
+      await repository.setMapping("My Cool Project", "my-cool-project");
+      const result = await repository.getDirectoryName("My Cool Project");
+      expect(result).toBe("my-cool-project");
+    });
+  });
+
+  describe("setMapping", () => {
+    it("should create index file if it does not exist", async () => {
+      await repository.setMapping("My Project", "my-project");
+      const indexPath = path.join(tempDir, ".index");
+      const exists = await fs.pathExists(indexPath);
+      expect(exists).toBe(true);
+    });
+
+    it("should store a mapping that can be retrieved", async () => {
+      await repository.setMapping("Test Project", "test-project");
+      const result = await repository.getDirectoryName("Test Project");
+      expect(result).toBe("test-project");
+    });
+
+    it("should add multiple mappings", async () => {
+      await repository.setMapping("Project A", "project-a");
+      await repository.setMapping("Project B", "project-b");
+
+      expect(await repository.getDirectoryName("Project A")).toBe("project-a");
+      expect(await repository.getDirectoryName("Project B")).toBe("project-b");
+    });
+
+    it("should overwrite existing mapping for same friendly name", async () => {
+      await repository.setMapping("My Project", "my-project-v1");
+      await repository.setMapping("My Project", "my-project-v2");
+
+      const result = await repository.getDirectoryName("My Project");
+      expect(result).toBe("my-project-v2");
+    });
+  });
+
+  describe("removeMapping", () => {
+    it("should remove an existing mapping", async () => {
+      await repository.setMapping("My Project", "my-project");
+      await repository.removeMapping("My Project");
+
+      const result = await repository.getDirectoryName("My Project");
+      expect(result).toBeNull();
+    });
+
+    it("should not throw when removing a non-existent mapping", async () => {
+      await expect(
+        repository.removeMapping("nonexistent")
+      ).resolves.not.toThrow();
+    });
+
+    it("should not affect other mappings", async () => {
+      await repository.setMapping("Project A", "project-a");
+      await repository.setMapping("Project B", "project-b");
+      await repository.removeMapping("Project A");
+
+      expect(await repository.getDirectoryName("Project A")).toBeNull();
+      expect(await repository.getDirectoryName("Project B")).toBe("project-b");
+    });
+  });
+
+  describe("getAllMappings", () => {
+    it("should return empty object when no mappings exist", async () => {
+      const result = await repository.getAllMappings();
+      expect(result).toEqual({});
+    });
+
+    it("should return all stored mappings", async () => {
+      await repository.setMapping("Project A", "project-a");
+      await repository.setMapping("Project B", "project-b");
+
+      const result = await repository.getAllMappings();
+      expect(result).toEqual({
+        "Project A": "project-a",
+        "Project B": "project-b",
+      });
+    });
+
+    it("should return a copy that does not affect internal state", async () => {
+      await repository.setMapping("My Project", "my-project");
+      const result = await repository.getAllMappings();
+      result["Injected"] = "injected";
+
+      const fresh = await repository.getAllMappings();
+      expect(fresh).not.toHaveProperty("Injected");
+    });
+  });
+
+  describe("rebuildIndex", () => {
+    it("should replace all existing mappings", async () => {
+      await repository.setMapping("Old Project", "old-project");
+
+      await repository.rebuildIndex([
+        { friendlyName: "New A", directoryName: "new-a" },
+        { friendlyName: "New B", directoryName: "new-b" },
+      ]);
+
+      expect(await repository.getDirectoryName("Old Project")).toBeNull();
+      expect(await repository.getDirectoryName("New A")).toBe("new-a");
+      expect(await repository.getDirectoryName("New B")).toBe("new-b");
+    });
+
+    it("should handle empty entries array", async () => {
+      await repository.setMapping("My Project", "my-project");
+      await repository.rebuildIndex([]);
+
+      const mappings = await repository.getAllMappings();
+      expect(mappings).toEqual({});
+    });
+  });
+
+  describe("corrupt index recovery", () => {
+    it("should return empty mappings when index file is invalid JSON", async () => {
+      await fs.writeFile(path.join(tempDir, ".index"), "not valid json");
+      const result = await repository.getAllMappings();
+      expect(result).toEqual({});
+    });
+
+    it("should return empty mappings when index has wrong structure", async () => {
+      await fs.writeFile(
+        path.join(tempDir, ".index"),
+        JSON.stringify({ version: 1, wrong: "structure" })
+      );
+      const result = await repository.getAllMappings();
+      expect(result).toEqual({});
+    });
+
+    it("should be recoverable by writing new mappings after corruption", async () => {
+      await fs.writeFile(path.join(tempDir, ".index"), "corrupt");
+      await repository.setMapping("My Project", "my-project");
+      expect(await repository.getDirectoryName("My Project")).toBe(
+        "my-project"
+      );
+    });
+  });
+
+  describe("index file format", () => {
+    it("should write valid JSON with version and mappings", async () => {
+      await repository.setMapping("My Project", "my-project");
+
+      const content = await fs.readFile(
+        path.join(tempDir, ".index"),
+        "utf-8"
+      );
+      const parsed = JSON.parse(content);
+
+      expect(parsed.version).toBe(1);
+      expect(parsed.mappings).toEqual({ "My Project": "my-project" });
+    });
+  });
+});

--- a/tests/main/protocols/mcp/adapters/mcp-project-resolution-adapter.test.ts
+++ b/tests/main/protocols/mcp/adapters/mcp-project-resolution-adapter.test.ts
@@ -1,0 +1,365 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import {
+  Request as MCPRequest,
+  ServerResult as MCPResponse,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  withProjectResolution,
+  ResolutionMode,
+} from "../../../../../src/main/protocols/mcp/adapters/mcp-project-resolution-adapter.js";
+import { ProjectNameResolverService } from "../../../../../src/data/services/project-name-resolver.js";
+import { MetadataRepository } from "../../../../../src/data/protocols/metadata-repository.js";
+import { ProjectIndexRepository } from "../../../../../src/data/protocols/project-index-repository.js";
+import { ProjectMetadata } from "../../../../../src/domain/entities/index.js";
+
+// --- Mock factories ---
+
+const makeResolver = (): ProjectNameResolverService => ({
+  resolve: vi.fn().mockResolvedValue(null),
+  resolveForCreation: vi.fn().mockResolvedValue({
+    directoryName: "resolved-dir",
+    friendlyName: "Original Name",
+    isNew: true,
+  }),
+});
+
+const makeMetadataRepo = (): MetadataRepository => ({
+  readMetadata: vi.fn().mockResolvedValue(null),
+  writeMetadata: vi.fn().mockResolvedValue(undefined),
+});
+
+const makeIndexRepo = (): ProjectIndexRepository => ({
+  getDirectoryName: vi.fn().mockResolvedValue(null),
+  setMapping: vi.fn().mockResolvedValue(undefined),
+  removeMapping: vi.fn().mockResolvedValue(undefined),
+  getAllMappings: vi.fn().mockResolvedValue({}),
+  rebuildIndex: vi.fn().mockResolvedValue(undefined),
+});
+
+const makeRequest = (
+  projectName?: string,
+  extra?: Record<string, unknown>
+): MCPRequest => ({
+  method: "tools/call",
+  params: {
+    name: "test_tool",
+    arguments: { ...(projectName !== undefined ? { projectName } : {}), ...extra },
+  },
+});
+
+const makeSuccessResponse = (): MCPResponse => ({
+  content: [{ type: "text", text: "ok" }],
+  isError: false,
+});
+
+const makeErrorResponse = (): MCPResponse => ({
+  content: [{ type: "text", text: "error" }],
+  isError: true,
+});
+
+describe("withProjectResolution", () => {
+  let resolver: ProjectNameResolverService;
+  let metadataRepo: MetadataRepository;
+  let indexRepo: ProjectIndexRepository;
+
+  beforeEach(() => {
+    resolver = makeResolver();
+    metadataRepo = makeMetadataRepo();
+    indexRepo = makeIndexRepo();
+  });
+
+  describe("read mode", () => {
+    it("should pass through when no projectName in arguments", async () => {
+      const innerHandler = vi.fn().mockResolvedValue(makeSuccessResponse());
+      const handler = await withProjectResolution(
+        Promise.resolve(innerHandler),
+        resolver,
+        metadataRepo,
+        indexRepo,
+        "read"
+      );
+
+      const request = makeRequest();
+      delete (request.params as any).arguments.projectName;
+      await handler(request);
+
+      expect(resolver.resolve).not.toHaveBeenCalled();
+      expect(innerHandler).toHaveBeenCalledWith(request);
+    });
+
+    it("should resolve friendly name to directory name", async () => {
+      vi.mocked(resolver.resolve).mockResolvedValue("resolved-project");
+      const innerHandler = vi.fn().mockResolvedValue(makeSuccessResponse());
+
+      const handler = await withProjectResolution(
+        Promise.resolve(innerHandler),
+        resolver,
+        metadataRepo,
+        indexRepo,
+        "read"
+      );
+
+      await handler(makeRequest("My Project"));
+
+      expect(resolver.resolve).toHaveBeenCalledWith("My Project");
+      const calledWith = innerHandler.mock.calls[0][0];
+      expect(calledWith.params.arguments.projectName).toBe("resolved-project");
+    });
+
+    it("should pass through original name when resolution returns null", async () => {
+      vi.mocked(resolver.resolve).mockResolvedValue(null);
+      const innerHandler = vi.fn().mockResolvedValue(makeSuccessResponse());
+
+      const handler = await withProjectResolution(
+        Promise.resolve(innerHandler),
+        resolver,
+        metadataRepo,
+        indexRepo,
+        "read"
+      );
+
+      const request = makeRequest("unknown-project");
+      await handler(request);
+
+      expect(innerHandler).toHaveBeenCalledWith(request);
+    });
+
+    it("should pass through when resolved name equals original name", async () => {
+      vi.mocked(resolver.resolve).mockResolvedValue("my-project");
+      const innerHandler = vi.fn().mockResolvedValue(makeSuccessResponse());
+
+      const handler = await withProjectResolution(
+        Promise.resolve(innerHandler),
+        resolver,
+        metadataRepo,
+        indexRepo,
+        "read"
+      );
+
+      const request = makeRequest("my-project");
+      await handler(request);
+
+      // Should pass the original request since names match
+      expect(innerHandler).toHaveBeenCalledWith(request);
+    });
+
+    it("should preserve other arguments when resolving", async () => {
+      vi.mocked(resolver.resolve).mockResolvedValue("resolved-dir");
+      const innerHandler = vi.fn().mockResolvedValue(makeSuccessResponse());
+
+      const handler = await withProjectResolution(
+        Promise.resolve(innerHandler),
+        resolver,
+        metadataRepo,
+        indexRepo,
+        "read"
+      );
+
+      await handler(makeRequest("My Project", { fileName: "test.md" }));
+
+      const calledWith = innerHandler.mock.calls[0][0];
+      expect(calledWith.params.arguments.projectName).toBe("resolved-dir");
+      expect(calledWith.params.arguments.fileName).toBe("test.md");
+    });
+
+    it("should lazily backfill metadata for projects without it in read mode", async () => {
+      vi.mocked(resolver.resolve).mockResolvedValue("resolved-dir");
+      vi.mocked(metadataRepo.readMetadata).mockResolvedValue(null); // No existing metadata
+      const innerHandler = vi.fn().mockResolvedValue(makeSuccessResponse());
+
+      const handler = await withProjectResolution(
+        Promise.resolve(innerHandler),
+        resolver,
+        metadataRepo,
+        indexRepo,
+        "read"
+      );
+
+      await handler(makeRequest("My Project"));
+
+      // Allow fire-and-forget promises to settle
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Lazy backfill should have written metadata using directory name as friendly name
+      expect(metadataRepo.writeMetadata).toHaveBeenCalledWith(
+        "resolved-dir",
+        expect.objectContaining({
+          friendlyName: "resolved-dir",
+          directoryName: "resolved-dir",
+        })
+      );
+      expect(indexRepo.setMapping).toHaveBeenCalledWith(
+        "resolved-dir",
+        "resolved-dir"
+      );
+    });
+
+    it("should NOT backfill metadata if it already exists", async () => {
+      vi.mocked(resolver.resolve).mockResolvedValue("resolved-dir");
+      vi.mocked(metadataRepo.readMetadata).mockResolvedValue({
+        friendlyName: "Existing Name",
+        directoryName: "resolved-dir",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      });
+      const innerHandler = vi.fn().mockResolvedValue(makeSuccessResponse());
+
+      const handler = await withProjectResolution(
+        Promise.resolve(innerHandler),
+        resolver,
+        metadataRepo,
+        indexRepo,
+        "read"
+      );
+
+      await handler(makeRequest("My Project"));
+
+      // Allow fire-and-forget promises to settle
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(metadataRepo.writeMetadata).not.toHaveBeenCalled();
+      expect(indexRepo.setMapping).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("write mode", () => {
+    it("should resolve for creation", async () => {
+      const innerHandler = vi.fn().mockResolvedValue(makeSuccessResponse());
+
+      const handler = await withProjectResolution(
+        Promise.resolve(innerHandler),
+        resolver,
+        metadataRepo,
+        indexRepo,
+        "write"
+      );
+
+      await handler(makeRequest("My New Project"));
+
+      expect(resolver.resolveForCreation).toHaveBeenCalledWith(
+        "My New Project"
+      );
+    });
+
+    it("should use resolved directory name in the handler call", async () => {
+      vi.mocked(resolver.resolveForCreation).mockResolvedValue({
+        directoryName: "my-new-project",
+        friendlyName: "My New Project",
+        isNew: true,
+      });
+      const innerHandler = vi.fn().mockResolvedValue(makeSuccessResponse());
+
+      const handler = await withProjectResolution(
+        Promise.resolve(innerHandler),
+        resolver,
+        metadataRepo,
+        indexRepo,
+        "write"
+      );
+
+      await handler(makeRequest("My New Project"));
+
+      const calledWith = innerHandler.mock.calls[0][0];
+      expect(calledWith.params.arguments.projectName).toBe("my-new-project");
+    });
+
+    it("should write metadata and update index for new projects on success", async () => {
+      vi.mocked(resolver.resolveForCreation).mockResolvedValue({
+        directoryName: "my-new-project",
+        friendlyName: "My New Project",
+        isNew: true,
+      });
+      const innerHandler = vi.fn().mockResolvedValue(makeSuccessResponse());
+
+      const handler = await withProjectResolution(
+        Promise.resolve(innerHandler),
+        resolver,
+        metadataRepo,
+        indexRepo,
+        "write"
+      );
+
+      await handler(makeRequest("My New Project"));
+
+      expect(metadataRepo.writeMetadata).toHaveBeenCalledWith(
+        "my-new-project",
+        expect.objectContaining({
+          friendlyName: "My New Project",
+          directoryName: "my-new-project",
+          createdAt: expect.any(String),
+        })
+      );
+      expect(indexRepo.setMapping).toHaveBeenCalledWith(
+        "My New Project",
+        "my-new-project"
+      );
+    });
+
+    it("should NOT write metadata for existing projects", async () => {
+      vi.mocked(resolver.resolveForCreation).mockResolvedValue({
+        directoryName: "existing-project",
+        friendlyName: "Existing Project",
+        isNew: false,
+      });
+      const innerHandler = vi.fn().mockResolvedValue(makeSuccessResponse());
+
+      const handler = await withProjectResolution(
+        Promise.resolve(innerHandler),
+        resolver,
+        metadataRepo,
+        indexRepo,
+        "write"
+      );
+
+      await handler(makeRequest("Existing Project"));
+
+      expect(metadataRepo.writeMetadata).not.toHaveBeenCalled();
+      expect(indexRepo.setMapping).not.toHaveBeenCalled();
+    });
+
+    it("should NOT write metadata when the handler returns an error", async () => {
+      vi.mocked(resolver.resolveForCreation).mockResolvedValue({
+        directoryName: "my-new-project",
+        friendlyName: "My New Project",
+        isNew: true,
+      });
+      const innerHandler = vi.fn().mockResolvedValue(makeErrorResponse());
+
+      const handler = await withProjectResolution(
+        Promise.resolve(innerHandler),
+        resolver,
+        metadataRepo,
+        indexRepo,
+        "write"
+      );
+
+      await handler(makeRequest("My New Project"));
+
+      expect(metadataRepo.writeMetadata).not.toHaveBeenCalled();
+      expect(indexRepo.setMapping).not.toHaveBeenCalled();
+    });
+
+    it("should not fail the operation if metadata write throws", async () => {
+      vi.mocked(resolver.resolveForCreation).mockResolvedValue({
+        directoryName: "my-new-project",
+        friendlyName: "My New Project",
+        isNew: true,
+      });
+      vi.mocked(metadataRepo.writeMetadata).mockRejectedValue(
+        new Error("write failed")
+      );
+      const innerHandler = vi.fn().mockResolvedValue(makeSuccessResponse());
+
+      const handler = await withProjectResolution(
+        Promise.resolve(innerHandler),
+        resolver,
+        metadataRepo,
+        indexRepo,
+        "write"
+      );
+
+      const result = await handler(makeRequest("My New Project"));
+      // Operation should still succeed despite metadata failure
+      expect(result.isError).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Project name normalization**: Clients can now use human-friendly project names (with spaces, special characters, unicode) that are automatically normalized to filesystem-safe directory names via a new `normalizeProjectName()` utility
- **Metadata & indexing system**: Each project gets a `.metadata.json` file tracking `friendlyName`, `directoryName`, and `createdAt`; a global `.index` file provides efficient friendly-name-to-directory-name lookup with file-locking for concurrent safety
- **MCP adapter-layer resolution**: A `withProjectResolution` higher-order wrapper at the adapter layer transparently resolves friendly names for all MCP tools, with lazy metadata backfill for existing projects on first access
- **Enriched API responses**: `list_projects` now returns objects with both `name` (directory) and `friendlyName` fields
- **Web UI updates**: Project list and detail pages display friendly names as primary titles with directory names as subtitles

## Architecture

The implementation follows the existing Clean Architecture patterns:

| Layer | New Components |
|-------|---------------|
| **Domain** | `ProjectMetadata`, `ProjectInfo` entity types |
| **Data** | `normalizeProjectName()` helper, `ProjectNameResolverService`, `rebuildProjectIndex` utility, `MetadataRepository` / `ProjectIndexRepository` protocols |
| **Infra** | `FsMetadataRepository`, `FsProjectIndexRepository` (with `FileLockService`) |
| **Main** | Factory functions, `mcp-project-resolution-adapter.ts` wrapper, updated `routes.ts` |
| **Web UI** | Updated `MemoryBankService`, `ProjectList`, project detail page |

Key design decision: Resolution is handled at the **MCP adapter layer** via a higher-order function, minimizing changes to existing controllers, use cases, and repositories. This keeps the cross-cutting concern centralized and easily extensible for future features (e.g., project tags).

## Test plan

- [x] 643 tests passing across 46 test files
- [x] 100% coverage on all new data/infra/adapter code (6 new test files, 108 new tests)
- [x] TypeScript compilation passes (`npm run build`)
- [x] All existing tests continue to pass (backwards compatible)
- [x] Lazy metadata backfill tested for existing projects without `.metadata.json`
- [x] Collision detection tested for normalized name conflicts
- [x] Unicode transliteration and edge cases covered in normalization tests


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new project name resolution and persistence paths (metadata files + global index) and changes MCP tool inputs/outputs (e.g., `list_projects`) while introducing background index rebuild on startup, so regressions could affect project routing and filesystem writes.
> 
> **Overview**
> **Adds friendly project names end-to-end** by introducing `normalizeProjectName`, a `ProjectNameResolver`, and a new `.metadata.json` + global `.index` mapping layer (with locking) to map user-friendly names to filesystem-safe directory names.
> 
> **Updates the MCP layer** to transparently resolve `projectName` for all read/write tools via `withProjectResolution`, backfill missing metadata on first access, and enrich `list_projects` responses to return `{ name, friendlyName }` objects; also triggers an async `rebuildProjectIndex` on MCP server startup.
> 
> **Polishes filesystem/UI behavior** by hiding dotfiles (e.g., `.metadata.json`, `.index`) from `listFiles`, and updating the web UI + service layer to display/search by `friendlyName` while still using directory `name` for routing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da6b39339393595f889576309620576deaf8a242. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->